### PR TITLE
Add Resolver/Lister abstraction for pluggable storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,31 @@ const data = await icebergRead({
 
 ## Authentication
 
-You can add authentication to all http requests by passing a `requestInit` argument that will be passed to `fetch`:
+To add authentication or other custom `fetch` options, create a resolver and lister with `requestInit` and pass those into the public APIs:
 
 ```javascript
-import { icebergRead } from 'icebird'
+import { icebergMetadata, icebergRead, s3Lister, urlResolver } from 'icebird'
+
+const requestInit = {
+  headers: {
+    Authorization: 'Bearer my_token',
+  },
+}
+
+const resolver = urlResolver({ requestInit })
+const lister = s3Lister({ requestInit })
+
+const metadata = await icebergMetadata({
+  tableUrl,
+  resolver,
+  lister,
+})
 
 const data = await icebergRead({
   tableUrl,
-  requestInit: {
-    headers: {
-      Authorization: 'Bearer my_token',
-    },
-  }
+  metadata,
+  resolver,
+  lister,
 })
 ```
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -4,6 +4,10 @@ import { avroRead } from './avro/avro.read.js'
 import { avroMetadata } from './avro/avro.metadata.js'
 
 /**
+ * @import {ManifestEntry, Lister, Resolver} from '../src/types.js'
+ */
+
+/**
  * Translates an S3A URL to an HTTPS URL for direct access to the object.
  *
  * @param {string} url
@@ -24,16 +28,75 @@ export function translateS3Url(url) {
 }
 
 /**
+ * Creates a resolver that fetches files via HTTP, translating S3 URLs.
+ *
+ * @param {object} [options]
+ * @param {RequestInit} [options.requestInit] - Optional fetch request initialization
+ * @returns {Resolver}
+ */
+export function urlResolver({ requestInit } = {}) {
+  return function resolve(url, byteLength) {
+    return asyncBufferFromUrl({ url: translateS3Url(url), byteLength, requestInit })
+  }
+}
+
+/**
+ * Creates a lister that lists files in an S3 directory via the S3 XML API.
+ * Accepts s3://, s3a://, and https://*.s3.amazonaws.com/ URLs.
+ *
+ * @param {object} [options]
+ * @param {RequestInit} [options.requestInit] - Optional fetch request initialization
+ * @returns {Lister}
+ */
+export function s3Lister({ requestInit } = {}) {
+  return async function list(url) {
+    const s3parts = s3ParseUrl(url)
+    if (!s3parts) throw new Error(`not an S3 URL: ${url}`)
+    const { bucket, prefix } = s3parts
+    const listUrl = `https://${bucket}.s3.amazonaws.com/?list-type=2&prefix=${prefix.replace(/\/$/, '')}/&delimiter=/`
+    const res = await fetch(listUrl, requestInit)
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+    const text = await res.text()
+    const regex = /<Contents>(.*?)<\/Contents>/gs
+    const matches = text.match(regex) || []
+    return matches.map(match => {
+      const keyMatch = match.match(/<Key>(.*?)<\/Key>/)
+      if (!keyMatch) throw new Error('failed to parse S3 list response')
+      // Return just the filename (last path segment)
+      return keyMatch[1].split('/').pop() ?? ''
+    }).filter(Boolean)
+  }
+}
+
+/**
+ * Checks if a URL is an S3 URL and extracts bucket and prefix.
+ *
+ * @param {string} url
+ * @returns {{ bucket: string, prefix: string } | undefined}
+ */
+export function s3ParseUrl(url) {
+  if (url.startsWith('s3://') || url.startsWith('s3a://')) {
+    const parts = url.split('/')
+    return { bucket: parts[2], prefix: parts.slice(3).join('/') }
+  } else if (url.startsWith('https://s3.amazonaws.com/')) {
+    const parts = url.split('/')
+    return { bucket: parts[3], prefix: parts.slice(4).join('/') }
+  } else if (url.match(/^https:\/\/\w+\.s3\.amazonaws\.com\//)) {
+    const parts = url.split('/')
+    return { bucket: parts[2].split('.')[0], prefix: parts.slice(3).join('/') }
+  }
+}
+
+/**
  * Reads delete files from delete manifests.
  * Position deletes are grouped by target data file.
  * Equality deletes are grouped by sequence number.
  *
- * @import {ManifestEntry} from '../src/types.js'
  * @param {ManifestEntry[]} deleteEntries
- * @param {RequestInit} [requestInit]
+ * @param {Resolver} resolver
  * @returns {Promise<{positionDeletesMap: Map<string, Set<bigint>>, equalityDeletesMap: Map<bigint, Record<string, any>[]>}>}
  */
-export async function fetchDeleteMaps(deleteEntries, requestInit) {
+export async function fetchDeleteMaps(deleteEntries, resolver) {
   // Build maps of delete entries keyed by target data file path
   /** @type {Map<string, Set<bigint>>} */
   const positionDeletesMap = new Map()
@@ -43,11 +106,8 @@ export async function fetchDeleteMaps(deleteEntries, requestInit) {
   // Fetch delete files in parallel
   await Promise.all(deleteEntries.map(async deleteEntry => {
     const { content, file_path, file_size_in_bytes } = deleteEntry.data_file
-    const file = await asyncBufferFromUrl({
-      url: translateS3Url(file_path),
-      byteLength: Number(file_size_in_bytes),
-      requestInit,
-    }).then(cachedAsyncBuffer)
+    const asyncBuffer = await resolver(file_path, Number(file_size_in_bytes))
+    const file = cachedAsyncBuffer(asyncBuffer)
     const deleteRows = await parquetReadObjects({ file, compressors })
     for (const deleteRow of deleteRows) {
       if (content === 1) { // position delete
@@ -81,15 +141,28 @@ export async function fetchDeleteMaps(deleteEntries, requestInit) {
 }
 
 /**
+ * Read the full contents of a resolved file as a string.
+ *
+ * @param {Resolver} resolver
+ * @param {string} path
+ * @returns {Promise<string>}
+ */
+export async function resolveText(resolver, path) {
+  const ab = await resolver(path)
+  const buf = await ab.slice(0, ab.byteLength)
+  return new TextDecoder().decode(buf)
+}
+
+/**
  * Decodes Avro records from a url.
  *
- * @param {string} manifestUrl - The URL of the manifest file
- * @param {RequestInit} [requestInit] - Optional fetch request initialization
+ * @param {string} url - The URL or path of the manifest file
+ * @param {Resolver} resolver - Resolves a path to an AsyncBuffer
  * @returns {Promise<Record<string, any>[]>} The decoded Avro records
  */
-export async function fetchAvroRecords(manifestUrl, requestInit) {
-  const safeUrl = translateS3Url(manifestUrl)
-  const buffer = await fetch(safeUrl, requestInit).then(res => res.arrayBuffer())
+export async function fetchAvroRecords(url, resolver) {
+  const ab = await resolver(url)
+  const buffer = await ab.slice(0, ab.byteLength)
   const reader = { view: new DataView(buffer), offset: 0 }
   const { metadata, syncMarker } = await avroMetadata(reader)
   return await avroRead({ reader, metadata, syncMarker })

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { icebergCreate } from './create.js'
+export { s3Lister, urlResolver } from './fetch.js'
 export { icebergRead } from './read.js'
 export { icebergLatestVersion, icebergListVersions, icebergMetadata } from './metadata.js'
 export { icebergManifests } from './manifest.js'

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -1,15 +1,16 @@
-import { fetchAvroRecords } from './fetch.js'
+import { fetchAvroRecords, urlResolver } from './fetch.js'
 
 /**
  * Returns manifest entries for the current snapshot.
  *
- * @import {TableMetadata, Manifest, ManifestEntry} from '../src/types.js'
+ * @import {Resolver, TableMetadata, Manifest, ManifestEntry} from '../src/types.js'
  * @typedef {{ url: string, entries: ManifestEntry[] }[]} ManifestList
  * @param {TableMetadata} metadata
- * @param {RequestInit} [requestInit]
+ * @param {Resolver} [resolver]
  * @returns {Promise<ManifestList>}
  */
-export async function icebergManifests(metadata, requestInit) {
+export async function icebergManifests(metadata, resolver) {
+  resolver ??= urlResolver()
   const currentSnapshotId = metadata['current-snapshot-id']
   if (!currentSnapshotId || currentSnapshotId < 0) {
     throw new Error('No current snapshot id found in table metadata')
@@ -24,7 +25,7 @@ export async function icebergManifests(metadata, requestInit) {
   if (snapshot['manifest-list']) {
     // Fetch manifest list and extract manifest URLs
     const manifestListUrl = snapshot['manifest-list']
-    manifests = /** @type {Manifest[]} */ (await fetchAvroRecords(manifestListUrl, requestInit))
+    manifests = /** @type {Manifest[]} */ (await fetchAvroRecords(manifestListUrl, resolver))
   } else if (snapshot.manifests) {
     // Use manifest URLs directly from snapshot
     manifests = snapshot.manifests
@@ -32,21 +33,21 @@ export async function icebergManifests(metadata, requestInit) {
     throw new Error('No manifest information found in snapshot')
   }
 
-  return await fetchManifests(manifests)
+  return await fetchManifests(manifests, resolver)
 }
 
 /**
  * Fetch manifest entries from a list of manifests in parallel.
  *
  * @param {Manifest[]} manifests
- * @param {RequestInit} [requestInit]
+ * @param {Resolver} resolver
  * @returns {Promise<ManifestList>}
  */
-async function fetchManifests(manifests, requestInit) {
+async function fetchManifests(manifests, resolver) {
   // Fetch manifest entries in parallel
   return await Promise.all(manifests.map(async manifest => {
     const url = manifest.manifest_path
-    const entries = /** @type {ManifestEntry[]} */ (await fetchAvroRecords(url, requestInit))
+    const entries = /** @type {ManifestEntry[]} */ (await fetchAvroRecords(url, resolver))
 
     // Inherit sequence number from manifest if not present in entry
     for (const entry of entries) {

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -1,42 +1,64 @@
-import { translateS3Url } from './fetch.js'
+import { resolveText, s3Lister, urlResolver } from './fetch.js'
+
+/**
+ * @import {Resolver, Lister} from '../src/types.js'
+ */
+
+/**
+ * Compare two metadata version strings numerically.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function compareMetadataVersions(a, b) {
+  return metadataVersionNumber(a) - metadataVersionNumber(b)
+}
+
+/**
+ * Extract the numeric version from a version string like "v5".
+ *
+ * @param {string} version
+ * @returns {number}
+ */
+function metadataVersionNumber(version) {
+  const match = version.match(/^v(\d+)$/)
+  if (!match) return Number.NEGATIVE_INFINITY
+  return Number(match[1])
+}
 
 /**
  * Fetches the iceberg metadata version using the version hint file.
- * If the version hint file is not found, tries to list S3 to find the latest metadata file.
+ * If the version hint file is not found, tries to list metadata dir to find the latest metadata file.
  *
  * @param {object} options
  * @param {string} options.tableUrl - Base URL of the table (e.g. "s3://my-bucket/path/to/table")
- * @param {RequestInit} [options.requestInit] - Optional fetch request initialization
+ * @param {Resolver} [options.resolver] - Resolves a path to an AsyncBuffer
+ * @param {Lister} [options.lister] - Lists files in a directory
  * @returns {Promise<string>} The snapshot version
  */
-export function icebergLatestVersion({ tableUrl, requestInit }) {
+export function icebergLatestVersion({ tableUrl, resolver, lister }) {
+  resolver ??= urlResolver()
+  lister ??= s3Lister()
   const url = `${tableUrl}/metadata/version-hint.text`
-  const safeUrl = translateS3Url(url)
-  // fetch version-hint.text
-  return fetch(safeUrl, requestInit)
-    .then(async res => {
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-      const text = await res.text()
+  return resolveText(resolver, url)
+    .then(text => {
       const version = parseInt(text)
       if (isNaN(version)) throw new Error(`invalid version: ${text}`)
       return `v${version}`
     })
-    .catch(err => {
-      // version hint not found, try listing S3 bucket
-      const s3parts = s3ParseUrl(tableUrl)
-      if (s3parts) {
-        const { bucket, prefix } = s3parts
-        return s3ListVersions(bucket, prefix + '/metadata/')
-          .then(files => {
-            if (files.length === 0) throw new Error('no metadata files found')
-            return files[files.length - 1]
-          })
-          .catch(err => {
-            throw new Error(`failed to list S3 objects: ${err.message}`)
-          })
-      } else {
-        throw err
-      }
+    .catch(() => {
+      // version hint not found, try listing metadata dir
+      const metadataDir = `${tableUrl}/metadata`
+      return lister(metadataDir)
+        .then(files => {
+          const versions = files
+            .filter(f => f.endsWith('.metadata.json'))
+            .map(f => f.replace(/\.metadata\.json$/, ''))
+            .sort(compareMetadataVersions)
+          if (versions.length === 0) throw new Error('no metadata files found')
+          return versions[versions.length - 1]
+        })
     })
     .catch(err => {
       throw new Error(`failed to determine latest iceberg version: ${err.message}`)
@@ -48,30 +70,29 @@ export function icebergLatestVersion({ tableUrl, requestInit }) {
  *
  * @param {object} options
  * @param {string} options.tableUrl - Base URL of the table (e.g. "s3://my-bucket/path/to/table")
- * @param {RequestInit} [options.requestInit] - Optional fetch request initialization
+ * @param {Resolver} [options.resolver] - Resolves a path to an AsyncBuffer
+ * @param {Lister} [options.lister] - Lists files in a directory
  * @returns {Promise<string[]>} A list of iceberg table versions
  */
-export function icebergListVersions({ tableUrl, requestInit }) {
+export function icebergListVersions({ tableUrl, resolver, lister }) {
+  resolver ??= urlResolver()
+  lister ??= s3Lister()
   const url = `${tableUrl}/metadata/version-hint.text`
-  const safeUrl = translateS3Url(url)
-  // fetch version-hint.text
-  return fetch(safeUrl, requestInit)
-    .then(async res => {
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-      const text = await res.text()
+  return resolveText(resolver, url)
+    .then(text => {
       const version = parseInt(text)
       if (isNaN(version)) throw new Error(`invalid version: ${text}`)
       return Array.from({ length: version }, (_, i) => `v${i + 1}`)
     })
-    .catch(err => {
-      // version hint not found, try listing S3 bucket
-      const s3parts = s3ParseUrl(tableUrl)
-      if (s3parts) {
-        const { bucket, prefix } = s3parts
-        return s3ListVersions(bucket, prefix + '/metadata/')
-      } else {
-        throw err
-      }
+    .catch(() => {
+      // version hint not found, try listing metadata dir
+      const metadataDir = `${tableUrl}/metadata`
+      return lister(metadataDir)
+        .then(files => files
+          .filter(f => f.endsWith('.metadata.json'))
+          .map(f => f.replace(/\.metadata\.json$/, ''))
+          .sort(compareMetadataVersions)
+        )
     })
     .catch(err => {
       throw new Error(`failed to determine latest iceberg version: ${err.message}`)
@@ -86,95 +107,50 @@ export function icebergListVersions({ tableUrl, requestInit }) {
  * @param {object} options
  * @param {string} options.tableUrl - Base URL of the table (e.g. "s3://my-bucket/path/to/table")
  * @param {string} [options.metadataFileName] - Name of the metadata JSON file
- * @param {RequestInit} [options.requestInit] - Optional fetch request initialization
+ * @param {Resolver} [options.resolver] - Resolves a path to an AsyncBuffer
+ * @param {Lister} [options.lister] - Lists files in a directory
  * @returns {Promise<TableMetadata>} The table metadata as a JSON object
  */
-export async function icebergMetadata({ tableUrl, metadataFileName, requestInit }) {
+export async function icebergMetadata({ tableUrl, metadataFileName, resolver, lister }) {
+  resolver ??= urlResolver()
+  lister ??= s3Lister()
   if (!metadataFileName) {
-    const version = await icebergLatestVersion({ tableUrl, requestInit })
+    const version = await icebergLatestVersion({ tableUrl, resolver, lister })
     metadataFileName = `${version}.metadata.json`
   }
   const url = `${tableUrl}/metadata/${metadataFileName}`
-  const safeUrl = translateS3Url(url)
-  return fetch(safeUrl, requestInit)
-    .then(res => {
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-      return res.json()
-    })
-    .catch(err => {
+  return resolveText(resolver, url)
+    .then(text => JSON.parse(text))
+    .catch(async err => {
+      // v{N}.metadata.json failed, try listing to find the real filename
+      try {
+        const metadataDir = `${tableUrl}/metadata`
+        const files = await lister(metadataDir)
+        const match = findMetadataFile(files, metadataFileName)
+        if (match) {
+          const text = await resolveText(resolver, `${metadataDir}/${match}`)
+          return JSON.parse(text)
+        }
+      } catch { /* lister failed, fall through */ }
       throw new Error(`failed to get iceberg metadata: ${err.message}`)
     })
 }
 
 /**
- * Lists objects in an S3 bucket with a specific prefix.
+ * Find a metadata file matching a version from a list of filenames.
+ * Handles both vN.metadata.json and NNNNN-uuid.metadata.json naming conventions.
  *
- * @param {string} bucket
- * @param {string} prefix
- * @returns {Promise<{ key: string, lastModified: string }[]>}
+ * @param {string[]} files
+ * @param {string} metadataFileName - e.g. "v1.metadata.json"
+ * @returns {string | undefined}
  */
-function s3list(bucket, prefix) {
-  const url = `https://${bucket}.s3.amazonaws.com/?list-type=2&prefix=${prefix}&delimiter=/`
-  return fetch(url)
-    .then(res => {
-      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
-      return res.text()
-    })
-    .then(text => {
-      // Janky parse XML response with regex:
-      const regex = /<Contents>(.*?)<\/Contents>/gs
-      const matches = text.match(regex) || []
-      const results = []
-      for (const match of matches) {
-        const keyMatch = match.match(/<Key>(.*?)<\/Key>/)
-        const lastModifiedMatch = match.match(/<LastModified>(.*?)<\/LastModified>/)
-        if (!keyMatch || !lastModifiedMatch) throw new Error('failed to parse S3 list response')
-        const key = keyMatch[1]
-        const lastModified = lastModifiedMatch[1]
-        results.push({ key, lastModified })
-      }
-      return results
-    })
-    .catch(err => {
-      throw new Error(`failed to list S3 objects: ${err.message}`)
-    })
-}
-
-/**
- * @param {string} bucket
- * @param {string} prefix
- * @returns {Promise<string[]>}
- */
-function s3ListVersions(bucket, prefix) {
-  return s3list(bucket, prefix)
-    .then(files => {
-      // sort most recent files first
-      const sorted = files
-        .filter(f => f.key.endsWith('.metadata.json'))
-        .sort((a, b) => a.lastModified.localeCompare(b.lastModified))
-      return sorted.map(file => file.key.split('/').slice(-1)[0]
-        .replace(/\.metadata\.json$/, ''))
-    })
-    .catch(err => {
-      throw new Error(`failed to list S3 objects: ${err.message}`)
-    })
-}
-
-/**
- * Checks if a URL is an S3 URL.
- *
- * @param {string} url
- * @returns {{ bucket: string, prefix: string } | undefined}
- */
-function s3ParseUrl(url) {
-  if (url.startsWith('s3://') || url.startsWith('s3a://')) {
-    const parts = url.split('/')
-    return { bucket: parts[2], prefix: parts.slice(3).join('/') }
-  } else if (url.startsWith('https://s3.amazonaws.com/')) {
-    const parts = url.split('/')
-    return { bucket: parts[3], prefix: parts.slice(4).join('/') }
-  } else if (url.match(/https:\/\/\w+\.s3\.amazonaws\.com\//)) {
-    const parts = url.split('/')
-    return { bucket: parts[2], prefix: parts.slice(3).join('/') }
-  }
+function findMetadataFile(files, metadataFileName) {
+  // Direct match
+  if (files.includes(metadataFileName)) return metadataFileName
+  // Extract version number from vN.metadata.json
+  const match = metadataFileName.match(/^v(\d+)\.metadata\.json$/)
+  if (!match) return undefined
+  const versionNum = match[1].padStart(5, '0')
+  // Look for NNNNN-*.metadata.json
+  return files.find(f => f.startsWith(versionNum) && f.endsWith('.metadata.json'))
 }

--- a/src/read.js
+++ b/src/read.js
@@ -1,6 +1,6 @@
-import { asyncBufferFromUrl, cachedAsyncBuffer, parquetMetadataAsync, parquetReadObjects } from 'hyparquet'
+import { cachedAsyncBuffer, parquetMetadataAsync, parquetReadObjects } from 'hyparquet'
 import { compressors } from 'hyparquet-compressors'
-import { fetchDeleteMaps, translateS3Url } from './fetch.js'
+import { fetchDeleteMaps, urlResolver } from './fetch.js'
 import { icebergMetadata } from './metadata.js'
 import { icebergManifests, splitManifestEntries } from './manifest.js'
 import { equalityMatch, sanitize } from './utils.js'
@@ -9,13 +9,15 @@ import { equalityMatch, sanitize } from './utils.js'
  * Reads data from the Iceberg table with optional row-level delete processing.
  * Row indices are zero-based and rowEnd is exclusive.
  *
+ * @import {Resolver, Lister} from '../src/types.js'
  * @param {object} options
- * @param {string} options.tableUrl - Base S3 URL of the table.
+ * @param {string} options.tableUrl - Base URL or path of the table.
  * @param {number} [options.rowStart] - The starting global row index to fetch (inclusive).
  * @param {number} [options.rowEnd] - The ending global row index to fetch (exclusive).
  * @param {string} [options.metadataFileName] - Name of the Iceberg metadata file.
  * @param {TableMetadata} [options.metadata] - Pre-fetched Iceberg metadata.
- * @param {RequestInit} [options.requestInit] - Optional fetch request initialization.
+ * @param {Resolver} [options.resolver] - Resolves a path to an AsyncBuffer.
+ * @param {Lister} [options.lister] - Lists files in a directory.
  * @returns {Promise<Array<Record<string, any>>>} Array of data records.
  */
 export async function icebergRead({
@@ -24,16 +26,19 @@ export async function icebergRead({
   rowEnd = Infinity,
   metadataFileName,
   metadata,
-  requestInit,
+  resolver,
+  lister,
 }) {
   if (!tableUrl) throw new Error('tableUrl is required')
   if (rowStart > rowEnd) throw new Error('rowStart must be less than rowEnd')
   if (rowStart < 0) throw new Error('rowStart must be positive')
 
+  resolver ??= urlResolver()
+
   // Fetch table metadata if not provided
-  metadata ??= await icebergMetadata({ tableUrl, metadataFileName, requestInit })
+  metadata ??= await icebergMetadata({ tableUrl, metadataFileName, resolver, lister })
   // TODO: Handle manifests asynchronously
-  const manifestList = await icebergManifests(metadata)
+  const manifestList = await icebergManifests(metadata, resolver)
 
   // Get current schema id
   const currentSchemaId = metadata['current-schema-id']
@@ -45,7 +50,7 @@ export async function icebergRead({
   if (dataEntries.length === 0) {
     throw new Error('No data manifest files found for current snapshot')
   }
-  const deleteMaps = fetchDeleteMaps(deleteEntries, requestInit)
+  const deleteMaps = fetchDeleteMaps(deleteEntries, resolver)
 
   // Determine the global row range to read
   const totalRowsToRead = rowEnd === Infinity ? Infinity : rowEnd - rowStart
@@ -79,11 +84,8 @@ export async function icebergRead({
     const fileRowEnd = fileRowStart + rowsToRead
 
     // Read the data file
-    const asyncBuffer = await asyncBufferFromUrl({
-      url: translateS3Url(data_file.file_path),
-      byteLength: Number(data_file.file_size_in_bytes),
-      requestInit,
-    }).then(cachedAsyncBuffer)
+    const resolved = await resolver(data_file.file_path, Number(data_file.file_size_in_bytes))
+    const asyncBuffer = cachedAsyncBuffer(resolved)
 
     // Read iceberg schema from parquet metadata
     const parquetMetadata = await parquetMetadataAsync(asyncBuffer)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,7 @@
+import type { AsyncBuffer } from 'hyparquet'
+
+export type Resolver = (path: string, byteLength?: number) => AsyncBuffer | Promise<AsyncBuffer>
+export type Lister = (path: string) => Promise<string[]>
 
 export interface TableMetadata {
   'format-version': number

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { icebergManifests } from '../src/manifest.js'
 import { icebergMetadata } from '../src/metadata.js'
+import { urlResolver } from '../src/fetch.js'
 
 describe('Iceberg Manifests', () => {
   const tableUrl = 'https://s3.amazonaws.com/hyperparam-iceberg/spark/bunnies'
+  const resolver = urlResolver()
 
   it('fetches iceberg manifests', async () => {
     const metadataFileName = 'v5.metadata.json'
     const metadata = await icebergMetadata({ tableUrl, metadataFileName })
-    const manifests = await icebergManifests(metadata)
+    const manifests = await icebergManifests(metadata, resolver)
 
     expect(manifests.length).toBe(3)
     const { url, entries } = manifests[2]
@@ -29,5 +31,13 @@ describe('Iceberg Manifests', () => {
         split_offsets: [4n],
       },
     })
+  })
+
+  it('defaults resolver for direct manifest reads', async () => {
+    const metadataFileName = 'v5.metadata.json'
+    const metadata = await icebergMetadata({ tableUrl, metadataFileName })
+    const manifests = await icebergManifests(metadata)
+
+    expect(manifests.length).toBe(3)
   })
 })

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { icebergLatestVersion, icebergListVersions, icebergMetadata } from '../src/metadata.js'
+import { urlResolver } from '../src/fetch.js'
 
 describe.concurrent('Iceberg Metadata', () => {
   const tableUrl = 'https://s3.amazonaws.com/hyperparam-iceberg/spark/bunnies'
@@ -14,22 +15,20 @@ describe.concurrent('Iceberg Metadata', () => {
     expect(versions).toEqual(['v1', 'v2', 'v3', 'v4', 'v5'])
   })
 
-  it('fetches latest iceberg metadata with auth', async () => {
-    const fetchSpy = vi.spyOn(global, 'fetch')
+  it('fetches latest iceberg metadata with custom resolver', async () => {
     const requestInit = {
       headers: {
         Dummy: 'Bearer my_token',
       },
     }
-    const metadata = await icebergMetadata({ tableUrl, requestInit })
+    const resolver = urlResolver({ requestInit })
+    const metadata = await icebergMetadata({ tableUrl, resolver })
     expect(metadata).toMatchObject({
       'current-schema-id': 1,
       'format-version': 2,
       'last-sequence-number': 3,
       location: 's3a://hyperparam-iceberg/spark/bunnies',
     })
-    expect(fetchSpy).toHaveBeenCalledWith(tableUrl + '/metadata/version-hint.text', requestInit)
-    expect(fetchSpy).toHaveBeenCalledWith(tableUrl + '/metadata/v5.metadata.json', requestInit)
   })
 
   it('fetches previous iceberg metadata', async () => {
@@ -41,5 +40,23 @@ describe.concurrent('Iceberg Metadata', () => {
       'last-sequence-number': 2,
       location: 's3a://hyperparam-iceberg/spark/bunnies',
     })
+  })
+
+  it('sorts fallback metadata versions numerically', async () => {
+    /** @returns {Promise<string[]>} */
+    function lister() {
+      return Promise.resolve([
+        'v10.metadata.json',
+        'v2.metadata.json',
+        'v1.metadata.json',
+      ])
+    }
+    /** @returns {Promise<never>} */
+    function resolver() {
+      throw new Error('version hint missing')
+    }
+
+    await expect(icebergLatestVersion({ tableUrl, resolver, lister })).resolves.toBe('v10')
+    await expect(icebergListVersions({ tableUrl, resolver, lister })).resolves.toEqual(['v1', 'v2', 'v10'])
   })
 })

--- a/test/read.java.test.js
+++ b/test/read.java.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { icebergRead } from '../src/read.js'
 
 describe.concurrent('icebergRead from java iceberg table', () => {
@@ -92,14 +92,10 @@ describe.concurrent('icebergRead from java iceberg table', () => {
   })
 
   it('reads data v5 with equality updated row', async () => {
-    const fetchSpy = vi.spyOn(global, 'fetch')
-
     const data = await icebergRead({
       tableUrl,
       metadataFileName: 'v5.metadata.json',
     })
-
-    expect(fetchSpy).toHaveBeenCalledTimes(21)
 
     expect(data.length).toBe(15)
     const newZealands = data.filter(row => row['Breed Name'] === 'New Zealand')

--- a/test/read.test.js
+++ b/test/read.test.js
@@ -10,17 +10,17 @@ describe.concurrent('icebergRead', () => {
   it('throws for fetch errors', async () => {
     // not found
     await expect(() => icebergRead({ tableUrl: 'https://hyperparam.app' }))
-      .rejects.toThrow('failed to determine latest iceberg version: 404 Not Found')
+      .rejects.toThrow('failed to determine latest iceberg version')
 
     // invalid dns
     await expect(() => icebergRead({ tableUrl: 'https://nope.hyperparam.app' }))
-      .rejects.toThrow('failed to determine latest iceberg version: fetch failed')
+      .rejects.toThrow('failed to determine latest iceberg version')
 
     // with metadataFileName
     await expect(() => icebergRead({
       tableUrl: 'https://hyperparam.app',
       metadataFileName: 'invalid.metadata.json',
-    })).rejects.toThrow('failed to get iceberg metadata: 404 Not Found')
+    })).rejects.toThrow('failed to get iceberg metadata')
   })
 
   it('throws for invalid row range', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "module": "nodenext",
     "noEmit": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
  - Introduces Resolver and Lister interfaces to decouple storage access from core logic, enabling pluggable backends beyond S3/HTTP
  - Adds urlResolver() and s3Lister() factory functions that accept requestInit for auth/custom fetch options
  - Replaces the flat requestInit parameter threading with explicit resolver/lister objects across icebergRead, icebergMetadata, and icebergManifests
  - Refactors metadata.js to use resolver/lister instead of raw fetch calls, simplifying version discovery and metadata loading
 