### PR TITLE
REST Catalog support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 coverage
 *.tgz
 types
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -89,6 +89,52 @@ const data = await icebergRead({
 })
 ```
 
+## REST Catalog
+
+To read a table from an [Iceberg REST Catalog](https://iceberg.apache.org/rest-catalog-spec/), connect to the catalog and load the table metadata, then pass it to `icebergRead`:
+
+```javascript
+import {
+  icebergRead,
+  restCatalogConnect,
+  restCatalogListTables,
+  restCatalogLoadTable,
+} from 'icebird'
+
+const requestInit = {
+  headers: { Authorization: 'Bearer my_token' },
+}
+
+const ctx = await restCatalogConnect({
+  url: 'https://catalog.example.com',
+  warehouse: 'my-warehouse', // optional
+  requestInit,
+})
+
+const tables = await restCatalogListTables(ctx, { namespace: 'analytics' })
+
+const { metadata } = await restCatalogLoadTable(ctx, {
+  namespace: 'analytics',
+  table: 'orders',
+})
+
+const data = await icebergRead({
+  tableUrl: metadata.location,
+  metadata,
+  rowStart: 0,
+  rowEnd: 10,
+})
+```
+
+Multi-level namespaces can be passed as an array:
+
+```javascript
+const { metadata } = await restCatalogLoadTable(ctx, {
+  namespace: ['db', 'sub'],
+  table: 'orders',
+})
+```
+
 ## Supported Features
 
 Icebird aims to support reading any Iceberg table, but currently only supports a subset of the features. The following features are supported:
@@ -103,7 +149,7 @@ Icebird aims to support reading any Iceberg table, but currently only supports a
 | ORC Storage | ❌ |
 | Puffin Storage | ❌ |
 | File-based Catalog (version-hint.text) | ✅ |
-| REST Catalog | ❌ |
+| REST Catalog | ✅ |
 | Hive Catalog | ❌ |
 | Glue Catalog | ❌ |
 | Service-based Catalog | ❌ |

--- a/src/catalog.rest.js
+++ b/src/catalog.rest.js
@@ -1,0 +1,211 @@
+/**
+ * Iceberg REST Catalog client (read-only).
+ *
+ * Plain async functions over a stateless context object — no classes.
+ * The catalog client never imports from the read path; callers glue the
+ * two together by passing `metadata` and `metadata.location` from
+ * `restCatalogLoadTable` into `icebergRead`.
+ *
+ * @import {LoadTableResponse, RestCatalogContext, TableIdentifier, TableMetadata} from '../src/types.js'
+ */
+
+/**
+ * Connect to a REST catalog by fetching `/v1/config`.
+ * Returns a frozen context object that holds the prefix, defaults, overrides
+ * and the user-supplied requestInit (for auth) for use in subsequent calls.
+ *
+ * @param {object} options
+ * @param {string} options.url - catalog base URL, with or without trailing slash
+ * @param {string} [options.warehouse] - optional warehouse query param sent to /v1/config
+ * @param {RequestInit} [options.requestInit] - fetch options (e.g. Authorization header)
+ * @returns {Promise<RestCatalogContext>}
+ */
+export async function restCatalogConnect({ url, warehouse, requestInit }) {
+  const base = url.replace(/\/$/, '')
+  const configUrl = warehouse
+    ? `${base}/v1/config?warehouse=${encodeURIComponent(warehouse)}`
+    : `${base}/v1/config`
+  const res = await fetch(configUrl, requestInit)
+  if (!res.ok) await throwRestError(res)
+  const body = await res.json()
+  return Object.freeze({
+    url: base,
+    prefix: typeof body.prefix === 'string' ? body.prefix : '',
+    defaults: body.defaults ?? {},
+    overrides: body.overrides ?? {},
+    requestInit,
+  })
+}
+
+/**
+ * List namespaces. Multi-level namespaces are returned as arrays of strings.
+ * Follows pagination (`next-page-token`) until exhausted.
+ *
+ * @param {RestCatalogContext} ctx
+ * @param {object} [options]
+ * @param {string | string[]} [options.parent] - parent namespace to scope the listing
+ * @returns {Promise<string[][]>}
+ */
+export function restCatalogListNamespaces(ctx, { parent } = {}) {
+  /** @type {Record<string, string>} */
+  const params = {}
+  if (parent !== undefined) params.parent = encodeNamespace(parent)
+  return paginate(params, async query => {
+    const res = await restFetch(ctx, `namespaces${query}`)
+    const body = await res.json()
+    return { items: body.namespaces ?? [], nextPageToken: body['next-page-token'] }
+  })
+}
+
+/**
+ * List tables within a namespace.
+ * Follows pagination (`next-page-token`) until exhausted.
+ *
+ * @param {RestCatalogContext} ctx
+ * @param {object} options
+ * @param {string | string[]} options.namespace
+ * @returns {Promise<TableIdentifier[]>}
+ */
+export function restCatalogListTables(ctx, { namespace }) {
+  const ns = encodeNamespace(namespace)
+  return paginate({}, async query => {
+    const res = await restFetch(ctx, `namespaces/${ns}/tables${query}`)
+    const body = await res.json()
+    return { items: body.identifiers ?? [], nextPageToken: body['next-page-token'] }
+  })
+}
+
+/**
+ * Load a single table. Returns the inline TableMetadata, the metadata
+ * file location, and any per-table config the server returned.
+ *
+ * The returned `metadata` and `metadata.location` can be passed directly
+ * into `icebergRead({ tableUrl: metadata.location, metadata })`.
+ *
+ * @param {RestCatalogContext} ctx
+ * @param {object} options
+ * @param {string | string[]} options.namespace
+ * @param {string} options.table
+ * @returns {Promise<LoadTableResponse>}
+ */
+export async function restCatalogLoadTable(ctx, { namespace, table }) {
+  const ns = encodeNamespace(namespace)
+  const tbl = encodeURIComponent(table)
+  const res = await restFetch(ctx, `namespaces/${ns}/tables/${tbl}`)
+  const body = await res.json()
+  return {
+    metadataLocation: body['metadata-location'],
+    metadata: /** @type {TableMetadata} */ (body.metadata),
+    config: body.config ?? {},
+  }
+}
+
+/**
+ * Encode a namespace for use in a URL path segment.
+ * Multi-level namespaces are joined with the unit separator (%1F) per spec.
+ * Accepts either a dot-separated string ('db.sub') or an array (['db','sub']).
+ *
+ * @param {string | string[]} namespace
+ * @returns {string}
+ */
+function encodeNamespace(namespace) {
+  const parts = Array.isArray(namespace) ? namespace : namespace.split('.')
+  return parts.map(p => encodeURIComponent(p)).join('%1F')
+}
+
+/**
+ * Issue a request against the catalog, prepending /v1/{prefix?}/ and
+ * merging the context's requestInit with per-call init.
+ *
+ * @param {RestCatalogContext} ctx
+ * @param {string} path - path after /v1/{prefix}/
+ * @param {RequestInit} [init]
+ * @returns {Promise<Response>}
+ */
+async function restFetch(ctx, path, init) {
+  const prefixSegment = ctx.prefix ? `${ctx.prefix.replace(/^\/|\/$/g, '')}/` : ''
+  const fullUrl = `${ctx.url}/v1/${prefixSegment}${path}`
+  const merged = mergeRequestInit(ctx.requestInit, init)
+  const res = await fetch(fullUrl, merged)
+  if (!res.ok) await throwRestError(res)
+  return res
+}
+
+/**
+ * Merge two RequestInit objects, combining headers.
+ *
+ * @param {RequestInit} [a]
+ * @param {RequestInit} [b]
+ * @returns {RequestInit | undefined}
+ */
+function mergeRequestInit(a, b) {
+  if (!a) return b
+  if (!b) return a
+  return {
+    ...a,
+    ...b,
+    headers: { ...headersToObject(a.headers), ...headersToObject(b.headers) },
+  }
+}
+
+/**
+ * Normalize HeadersInit to a plain object.
+ *
+ * @param {HeadersInit} [h]
+ * @returns {Record<string, string>}
+ */
+function headersToObject(h) {
+  if (!h) return {}
+  if (h instanceof Headers) {
+    /** @type {Record<string, string>} */
+    const out = {}
+    h.forEach((v, k) => { out[k] = v })
+    return out
+  }
+  if (Array.isArray(h)) return Object.fromEntries(h)
+  return /** @type {Record<string, string>} */ (h)
+}
+
+/**
+ * Read an ErrorModel response and throw a descriptive Error.
+ *
+ * @param {Response} res
+ * @returns {Promise<never>}
+ */
+async function throwRestError(res) {
+  let detail = ''
+  try {
+    const body = await res.json()
+    if (body?.error) {
+      const { code, type, message } = body.error
+      detail = `${code ?? res.status} ${type ?? ''}: ${message ?? ''}`.trim()
+    }
+  } catch { /* not JSON */ }
+  throw new Error(detail || `${res.status} ${res.statusText}`)
+}
+
+/**
+ * Walk through paginated responses, concatenating items.
+ *
+ * @template T
+ * @param {Record<string, string>} baseParams - query params applied to every page
+ * @param {(query: string) => Promise<{items: T[], nextPageToken?: string}>} fetchPage
+ * @returns {Promise<T[]>}
+ */
+async function paginate(baseParams, fetchPage) {
+  /** @type {T[]} */
+  const out = []
+  let pageToken
+  while (true) {
+    const params = { ...baseParams }
+    if (pageToken) params.pageToken = pageToken
+    const keys = Object.keys(params)
+    const query = keys.length
+      ? '?' + keys.map(k => `${k}=${params[k]}`).join('&')
+      : ''
+    const { items, nextPageToken } = await fetchPage(query)
+    out.push(...items)
+    if (!nextPageToken) return out
+    pageToken = encodeURIComponent(nextPageToken)
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { icebergCreate } from './create.js'
+export { restCatalogConnect, restCatalogListNamespaces, restCatalogListTables, restCatalogLoadTable } from './catalog.rest.js'
 export { s3Lister, urlResolver } from './fetch.js'
 export { icebergRead } from './read.js'
 export { icebergLatestVersion, icebergListVersions, icebergMetadata } from './metadata.js'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -3,6 +3,25 @@ import type { AsyncBuffer } from 'hyparquet'
 export type Resolver = (path: string, byteLength?: number) => AsyncBuffer | Promise<AsyncBuffer>
 export type Lister = (path: string) => Promise<string[]>
 
+export interface RestCatalogContext {
+  url: string
+  prefix: string
+  defaults: Record<string, string>
+  overrides: Record<string, string>
+  requestInit?: RequestInit
+}
+
+export interface TableIdentifier {
+  namespace: string[]
+  name: string
+}
+
+export interface LoadTableResponse {
+  metadataLocation?: string
+  metadata: TableMetadata
+  config: Record<string, string>
+}
+
 export interface TableMetadata {
   'format-version': number
   'table-uuid': string

--- a/test/catalog.rest.test.js
+++ b/test/catalog.rest.test.js
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  restCatalogConnect,
+  restCatalogListNamespaces,
+  restCatalogListTables,
+  restCatalogLoadTable,
+} from '../src/catalog.rest.js'
+
+/**
+ * Builds a fetch mock that returns canned responses keyed by URL.
+ * Each handler can be a function (req) => Response/object, or a static value.
+ *
+ * @param {Record<string, any>} routes
+ * @returns {{ fn: any, calls: Array<{url: string, init: RequestInit | undefined}> }}
+ */
+function makeFetch(routes) {
+  /** @type {Array<{url: string, init: RequestInit | undefined}>} */
+  const calls = []
+  /**
+   * @param {string} url
+   * @param {RequestInit} [init]
+   * @returns {Promise<Response>}
+   */
+  function fn(url, init) {
+    calls.push({ url, init })
+    const handler = routes[url]
+    if (handler === undefined) {
+      return Promise.resolve(new Response(JSON.stringify({
+        error: { code: 404, type: 'NotFound', message: `no route for ${url}` },
+      }), { status: 404 }))
+    }
+    const value = typeof handler === 'function' ? handler({ url, init }) : handler
+    if (value instanceof Response) return Promise.resolve(value)
+    return Promise.resolve(new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+  }
+  return { fn, calls }
+}
+
+describe('REST Catalog client', () => {
+  /** @type {ReturnType<typeof makeFetch>} */
+  let mock
+
+  beforeEach(() => { mock = makeFetch({}) })
+  afterEach(() => { vi.unstubAllGlobals() })
+
+  it('restCatalogConnect parses /v1/config', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': { prefix: 'ws/main', defaults: { a: '1' }, overrides: { b: '2' } },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat/' })
+    expect(ctx.url).toBe('https://cat')
+    expect(ctx.prefix).toBe('ws/main')
+    expect(ctx.defaults).toEqual({ a: '1' })
+    expect(ctx.overrides).toEqual({ b: '2' })
+  })
+
+  it('restCatalogConnect handles missing prefix', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    expect(ctx.prefix).toBe('')
+    expect(ctx.defaults).toEqual({})
+    expect(ctx.overrides).toEqual({})
+  })
+
+  it('restCatalogConnect forwards warehouse query param', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config?warehouse=my%2Fwh': {},
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    await restCatalogConnect({ url: 'https://cat', warehouse: 'my/wh' })
+    expect(mock.calls[0].url).toBe('https://cat/v1/config?warehouse=my%2Fwh')
+  })
+
+  it('restCatalogListNamespaces single page', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': { prefix: '' },
+      'https://cat/v1/namespaces': { namespaces: [['db'], ['analytics']] },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    const result = await restCatalogListNamespaces(ctx)
+    expect(result).toEqual([['db'], ['analytics']])
+  })
+
+  it('restCatalogListNamespaces follows next-page-token', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+      'https://cat/v1/namespaces': { namespaces: [['a']], 'next-page-token': 'tok-1' },
+      'https://cat/v1/namespaces?pageToken=tok-1': { namespaces: [['b']], 'next-page-token': 'tok 2' },
+      'https://cat/v1/namespaces?pageToken=tok%202': { namespaces: [['c']] },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    const result = await restCatalogListNamespaces(ctx)
+    expect(result).toEqual([['a'], ['b'], ['c']])
+  })
+
+  it('restCatalogListNamespaces with parent encodes multi-level', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+      'https://cat/v1/namespaces?parent=db%1Fsub': { namespaces: [['db', 'sub', 'leaf']] },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    const result = await restCatalogListNamespaces(ctx, { parent: ['db', 'sub'] })
+    expect(result).toEqual([['db', 'sub', 'leaf']])
+  })
+
+  it('restCatalogListTables paginates and applies prefix', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': { prefix: 'ws/main' },
+      'https://cat/v1/ws/main/namespaces/db/tables': {
+        identifiers: [{ namespace: ['db'], name: 't1' }],
+        'next-page-token': 'p2',
+      },
+      'https://cat/v1/ws/main/namespaces/db/tables?pageToken=p2': {
+        identifiers: [{ namespace: ['db'], name: 't2' }],
+      },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    const tables = await restCatalogListTables(ctx, { namespace: 'db' })
+    expect(tables).toEqual([
+      { namespace: ['db'], name: 't1' },
+      { namespace: ['db'], name: 't2' },
+    ])
+  })
+
+  it('restCatalogLoadTable returns metadata and metadataLocation', async () => {
+    const metadata = {
+      'format-version': 2,
+      'table-uuid': 'abc',
+      location: 's3://bucket/table',
+      schemas: [],
+    }
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+      'https://cat/v1/namespaces/db/tables/orders': {
+        'metadata-location': 's3://bucket/table/metadata/v3.metadata.json',
+        metadata,
+        config: { 'client.region': 'us-east-1' },
+      },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    const result = await restCatalogLoadTable(ctx, { namespace: 'db', table: 'orders' })
+    expect(result.metadataLocation).toBe('s3://bucket/table/metadata/v3.metadata.json')
+    expect(result.metadata).toEqual(metadata)
+    expect(result.config).toEqual({ 'client.region': 'us-east-1' })
+  })
+
+  it('restCatalogLoadTable encodes multi-level namespace with %1F', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+      'https://cat/v1/namespaces/db%1Fsub/tables/orders': {
+        'metadata-location': 'x',
+        metadata: { location: 's3://x' },
+      },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    await restCatalogLoadTable(ctx, { namespace: ['db', 'sub'], table: 'orders' })
+    expect(mock.calls.some(c => c.url === 'https://cat/v1/namespaces/db%1Fsub/tables/orders')).toBe(true)
+  })
+
+  it('throws ErrorModel message on non-2xx', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+      'https://cat/v1/namespaces/db/tables/missing': () => new Response(JSON.stringify({
+        error: { code: 404, type: 'NoSuchTableException', message: 'Table not found' },
+      }), { status: 404 }),
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const ctx = await restCatalogConnect({ url: 'https://cat' })
+    await expect(restCatalogLoadTable(ctx, { namespace: 'db', table: 'missing' }))
+      .rejects.toThrow('404 NoSuchTableException: Table not found')
+  })
+
+  it('forwards Authorization header from requestInit', async () => {
+    mock = makeFetch({
+      'https://cat/v1/config': {},
+      'https://cat/v1/namespaces': { namespaces: [] },
+    })
+    vi.stubGlobal('fetch', mock.fn)
+
+    const requestInit = { headers: { Authorization: 'Bearer secret-token' } }
+    const ctx = await restCatalogConnect({ url: 'https://cat', requestInit })
+    await restCatalogListNamespaces(ctx)
+
+    for (const call of mock.calls) {
+      const headers = /** @type {Record<string,string>} */ (call.init?.headers)
+      expect(headers?.Authorization).toBe('Bearer secret-token')
+    }
+  })
+})


### PR DESCRIPTION
- Add read-only Iceberg REST Catalog client: `restCatalogConnect`, `restCatalogListNamespaces`, `restCatalogListTables`, `restCatalogLoadTable` (exported from `src/index.js`).
- Stateless design: `restCatalogConnect` fetches `/v1/config` and returns a frozen context (prefix, defaults, overrides, `requestInit`); other functions take that context as their first arg.
- Spec-compliant URL handling: multi-level namespaces joined with `%1F`, `next-page-token` pagination, ErrorModel responses surfaced as descriptive `Error`s.
- Auth via caller-supplied `requestInit` (merged headers per call) — no credentials in the library.
- Decoupled from the read path: `restCatalogLoadTable` returns `{ metadataLocation, metadata, config }` that callers pass straight into `icebergRead({ tableUrl: metadata.location, metadata })`.
- New shared types in `src/types.d.ts` (`RestCatalogContext`, `TableIdentifier`, `LoadTableResponse`, etc.).
