### PR TITLE
Resolver read and write

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -2,15 +2,16 @@ import { translateS3Url } from './fetch.js'
 import { uuid4 } from './utils.js'
 
 /**
+ * @import {Resolver} from '../src/types.js'
  * @param {object} options
  * @param {string} options.tableUrl - Base S3 URL of the table.
- * @param {(file: string) => Writer} options.writerFactory - Function to create writers for files in storage.
+ * @param {Resolver} options.resolver - Resolver with a writer method.
  * @param {Schema} [options.schema] - The schema of the table.
  * @returns {Promise<TableMetadata>} The Iceberg table metadata as a JSON object.
  */
 export async function icebergCreate ({
   tableUrl,
-  writerFactory,
+  resolver,
   schema,
 }) {
   if (!tableUrl) throw new Error('tableUrl is required')
@@ -46,15 +47,17 @@ export async function icebergCreate ({
     // statistics: [],
   }
 
+  if (!resolver.writer) throw new Error('resolver.writer is required')
+
   // write initial metadata
-  const metadataWriter = writerFactory(metadataUrl)
+  const metadataWriter = resolver.writer(metadataUrl)
   const metadataBytes = new TextEncoder().encode(JSON.stringify(metadata, null, 2))
   metadataWriter.appendBytes(metadataBytes)
   metadataWriter.finish()
 
   // write version-hint.text
   const versionHintUrl = translateS3Url(`${tableUrl}/version-hint.text`)
-  const versionHintWriter = writerFactory(versionHintUrl)
+  const versionHintWriter = resolver.writer(versionHintUrl)
   const versionHintBytes = new TextEncoder().encode(String(metadataVersion))
   versionHintWriter.appendBytes(versionHintBytes)
   versionHintWriter.finish()
@@ -63,7 +66,6 @@ export async function icebergCreate ({
 }
 
 /**
- * @import {Writer} from 'hyparquet-writer/src/types.js'
  * @import {Field, PartitionField, PartitionSpec, Schema, SortOrder, TableMetadata} from '../src/types.js'
  * @param {Field[]} fields
  * @returns {number}

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -35,8 +35,10 @@ export function translateS3Url(url) {
  * @returns {Resolver}
  */
 export function urlResolver({ requestInit } = {}) {
-  return function resolve(url, byteLength) {
-    return asyncBufferFromUrl({ url: translateS3Url(url), byteLength, requestInit })
+  return {
+    reader(url, byteLength) {
+      return asyncBufferFromUrl({ url: translateS3Url(url), byteLength, requestInit })
+    },
   }
 }
 
@@ -106,7 +108,7 @@ export async function fetchDeleteMaps(deleteEntries, resolver) {
   // Fetch delete files in parallel
   await Promise.all(deleteEntries.map(async deleteEntry => {
     const { content, file_path, file_size_in_bytes } = deleteEntry.data_file
-    const asyncBuffer = await resolver(file_path, Number(file_size_in_bytes))
+    const asyncBuffer = await resolver.reader(file_path, Number(file_size_in_bytes))
     const file = cachedAsyncBuffer(asyncBuffer)
     const deleteRows = await parquetReadObjects({ file, compressors })
     for (const deleteRow of deleteRows) {
@@ -148,7 +150,7 @@ export async function fetchDeleteMaps(deleteEntries, resolver) {
  * @returns {Promise<string>}
  */
 export async function resolveText(resolver, path) {
-  const ab = await resolver(path)
+  const ab = await resolver.reader(path)
   const buf = await ab.slice(0, ab.byteLength)
   return new TextDecoder().decode(buf)
 }
@@ -161,7 +163,7 @@ export async function resolveText(resolver, path) {
  * @returns {Promise<Record<string, any>[]>} The decoded Avro records
  */
 export async function fetchAvroRecords(url, resolver) {
-  const ab = await resolver(url)
+  const ab = await resolver.reader(url)
   const buffer = await ab.slice(0, ab.byteLength)
   const reader = { view: new DataView(buffer), offset: 0 }
   const { metadata, syncMarker } = await avroMetadata(reader)

--- a/src/read.js
+++ b/src/read.js
@@ -84,7 +84,7 @@ export async function icebergRead({
     const fileRowEnd = fileRowStart + rowsToRead
 
     // Read the data file
-    const resolved = await resolver(data_file.file_path, Number(data_file.file_size_in_bytes))
+    const resolved = await resolver.reader(data_file.file_path, Number(data_file.file_size_in_bytes))
     const asyncBuffer = cachedAsyncBuffer(resolved)
 
     // Read iceberg schema from parquet metadata

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,10 @@
 import type { AsyncBuffer } from 'hyparquet'
+import type { Writer } from 'hyparquet-writer/src/types.js'
 
-export type Resolver = (path: string, byteLength?: number) => AsyncBuffer | Promise<AsyncBuffer>
+export interface Resolver {
+  reader: (path: string, byteLength?: number) => AsyncBuffer | Promise<AsyncBuffer>
+  writer?: (path: string) => Writer
+}
 export type Lister = (path: string) => Promise<string[]>
 
 export interface RestCatalogContext {

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -18,11 +18,12 @@ describe('createIceberg', () => {
   it('creates a new Iceberg table', async () => {
     /** @type {Record<string, ByteWriter>} */
     const writers = {}
-    const writerFactory = vi.fn(path => {
+    const writer = vi.fn(path => {
       writers[path] = new ByteWriter()
       return writers[path]
     })
-    const metadata = await icebergCreate({ tableUrl, writerFactory })
+    const resolver = { reader: vi.fn(), writer }
+    const metadata = await icebergCreate({ tableUrl, resolver })
 
     // Check the metadata structure
     expect(metadata).toMatchObject({
@@ -47,16 +48,16 @@ describe('createIceberg', () => {
       'default-sort-order-id': 0,
     })
 
-    // Check that the writerFactory was called correctly
-    expect(writerFactory).toHaveBeenCalledWith(`${translatedTableUrl}/metadata/v1.metadata.json`)
-    expect(writerFactory).toHaveBeenCalledWith(`${translatedTableUrl}/version-hint.text`)
+    // Check that the writer was called correctly
+    expect(writer).toHaveBeenCalledWith(`${translatedTableUrl}/metadata/v1.metadata.json`)
+    expect(writer).toHaveBeenCalledWith(`${translatedTableUrl}/version-hint.text`)
     expect(writers[`${translatedTableUrl}/metadata/v1.metadata.json`].offset).toBe(573)
     expect(writers[`${translatedTableUrl}/version-hint.text`].offset).toBe(1)
 
   })
 
   it('throws an error if tableUrl is not provided', async () => {
-    const writerFactory = vi.fn()
-    await expect(icebergCreate({ tableUrl: '', writerFactory })).rejects.toThrow('tableUrl is required')
+    const resolver = { reader: vi.fn(), writer: vi.fn() }
+    await expect(icebergCreate({ tableUrl: '', resolver })).rejects.toThrow('tableUrl is required')
   })
 })

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { icebergLatestVersion, icebergListVersions, icebergMetadata } from '../src/metadata.js'
 import { urlResolver } from '../src/fetch.js'
 
+/**
+ * @import {Resolver} from '../src/types.js'
+ */
+
 describe.concurrent('Iceberg Metadata', () => {
   const tableUrl = 'https://s3.amazonaws.com/hyperparam-iceberg/spark/bunnies'
 
@@ -51,9 +55,11 @@ describe.concurrent('Iceberg Metadata', () => {
         'v1.metadata.json',
       ])
     }
-    /** @returns {Promise<never>} */
-    function resolver() {
-      throw new Error('version hint missing')
+    /** @type {Resolver} */
+    const resolver = {
+      reader() {
+        throw new Error('version hint missing')
+      },
     }
 
     await expect(icebergLatestVersion({ tableUrl, resolver, lister })).resolves.toBe('v10')


### PR DESCRIPTION
- Updates the `Resolver` API from a callable function to an object with `reader(...)` and optional `writer(...)` methods.
- Refactors table reads, metadata fetches, delete map fetches, and Avro reads to use `resolver.reader(...)`.
- Refactors `icebergCreate` to accept a resolver with `writer(...)` instead of a separate `writerFactory`.
- Adds TypeScript typings for resolver write support via `hyparquet-writer`.
- Updates create and metadata tests to cover the new resolver shape.