### PR TITLE
Append snapshot

### DIFF
--- a/src/avro/avro.write.js
+++ b/src/avro/avro.write.js
@@ -6,11 +6,13 @@ import { ByteWriter } from 'hyparquet-writer'
  * @param {AvroRecord} options.schema
  * @param {Record<string, any>[]} options.records
  * @param {number} [options.blockSize]
+ * @param {Record<string, string>} [options.metadata] - extra file-level metadata
  */
-export function avroWrite({ writer, schema, records, blockSize = 512 }) {
+export function avroWrite({ writer, schema, records, blockSize = 512, metadata }) {
   writer.appendUint32(0x016a624f) // Obj\x01
 
   const meta = {
+    ...metadata,
     'avro.schema': typeof schema === 'string' ? schema : JSON.stringify(schema),
     'avro.codec': 'null',
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { icebergAppend } from './write/append.js'
 export { icebergCreate } from './create.js'
 export { restCatalogConnect, restCatalogListNamespaces, restCatalogListTables, restCatalogLoadTable } from './catalog.rest.js'
 export { s3Lister, urlResolver } from './fetch.js'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -65,8 +65,8 @@ interface Field {
   required: boolean
   type: string // TODO
   doc?: string
-  'initial-default': any
-  'write-default': any
+  'initial-default'?: any
+  'write-default'?: any
 }
 
 export interface PartitionSpec {

--- a/src/write/append.js
+++ b/src/write/append.js
@@ -1,0 +1,192 @@
+import { fetchAvroRecords, translateS3Url } from '../fetch.js'
+import { uuid4 } from '../utils.js'
+import { writeParquet } from './parquet.js'
+import { writeDataManifest } from './manifest.js'
+import { writeManifestList } from './manifest-list.js'
+
+/**
+ * @import {Resolver, Manifest, Schema, Snapshot, TableMetadata} from '../../src/types.js'
+ */
+
+/**
+ * Append a single unpartitioned snapshot to an existing iceberg table.
+ *
+ * Writes a parquet data file, a manifest, a manifest list, a new
+ * vN+1.metadata.json, and updates version-hint.text. Only supports v2 tables
+ * with a flat unpartitioned schema and primitive column types.
+ *
+ * @param {object} options
+ * @param {string} options.tableUrl - Base URL of the table.
+ * @param {TableMetadata} options.metadata - Current table metadata.
+ * @param {Record<string, any>[]} options.records - Rows to append.
+ * @param {Resolver} options.resolver - Resolver with a writer method.
+ * @returns {Promise<TableMetadata>} The new table metadata, already persisted.
+ */
+export async function icebergAppend({ tableUrl, metadata, records, resolver }) {
+  if (!tableUrl) throw new Error('tableUrl is required')
+  if (!resolver?.writer) throw new Error('resolver.writer is required')
+  if (metadata['format-version'] !== 2) {
+    throw new Error(`unsupported format-version: ${metadata['format-version']}`)
+  }
+  const partitionSpec = metadata['partition-specs'].find(s => s['spec-id'] === metadata['default-spec-id'])
+  if (!partitionSpec || partitionSpec.fields.length) {
+    throw new Error('icebergAppend only supports unpartitioned tables')
+  }
+
+  const schema = metadata.schemas.find(s => s['schema-id'] === metadata['current-schema-id'])
+  if (!schema) throw new Error('current schema not found in metadata')
+
+  const snapshotId = newSnapshotId()
+  const sequenceNumber = BigInt(metadata['last-sequence-number'] ?? 0) + 1n
+  const dataUuid = uuid4()
+  const manifestUuid = uuid4()
+  const timestampMs = Date.now()
+
+  // 1. Write parquet data file
+  const dataPath = `${tableUrl}/data/${dataUuid}.parquet`
+  const dataWriter = resolver.writer(translateS3Url(dataPath))
+  writeParquet({ writer: dataWriter, schema, records })
+  const dataFileSize = BigInt(dataWriter.offset)
+
+  // 2. Write manifest
+  const manifestPath = `${tableUrl}/metadata/${manifestUuid}-m0.avro`
+  const manifestWriter = resolver.writer(translateS3Url(manifestPath))
+  writeDataManifest({
+    writer: manifestWriter,
+    schema,
+    snapshotId,
+    dataFile: {
+      content: 0,
+      file_path: dataPath,
+      file_format: 'parquet',
+      partition: {},
+      record_count: BigInt(records.length),
+      file_size_in_bytes: dataFileSize,
+      sort_order_id: 0,
+    },
+  })
+  const manifestLength = BigInt(manifestWriter.offset)
+
+  /** @type {Manifest} */
+  const newManifest = {
+    manifest_path: manifestPath,
+    manifest_length: manifestLength,
+    partition_spec_id: 0,
+    content: 0,
+    sequence_number: sequenceNumber,
+    min_sequence_number: sequenceNumber,
+    added_snapshot_id: snapshotId,
+    added_files_count: 1,
+    existing_files_count: 0,
+    deleted_files_count: 0,
+    added_rows_count: BigInt(records.length),
+    existing_rows_count: 0n,
+    deleted_rows_count: 0n,
+  }
+
+  // 3. Carry forward manifests from prior snapshot, then write new manifest list
+  const priorManifests = await loadPriorManifests(metadata, resolver)
+  const allManifests = [newManifest, ...priorManifests]
+  const manifestListPath = `${tableUrl}/metadata/snap-${snapshotId}-1-${manifestUuid}.avro`
+  const listWriter = resolver.writer(translateS3Url(manifestListPath))
+  writeManifestList({ writer: listWriter, snapshotId, sequenceNumber, manifests: allManifests })
+
+  // 4. Build the new snapshot
+  const prevSummary = currentSnapshot(metadata)?.summary
+  const prevTotals = {
+    records: BigInt(prevSummary?.['total-records'] ?? '0'),
+    size: BigInt(prevSummary?.['total-files-size'] ?? '0'),
+    files: BigInt(prevSummary?.['total-data-files'] ?? '0'),
+  }
+  /** @type {Snapshot} */
+  const snapshot = {
+    'snapshot-id': Number(snapshotId),
+    'sequence-number': Number(sequenceNumber),
+    'timestamp-ms': timestampMs,
+    'manifest-list': manifestListPath,
+    summary: {
+      operation: 'append',
+      'added-data-files': '1',
+      'added-records': String(records.length),
+      'added-files-size': String(dataFileSize),
+      'changed-partition-count': '1',
+      'total-records': String(prevTotals.records + BigInt(records.length)),
+      'total-files-size': String(prevTotals.size + dataFileSize),
+      'total-data-files': String(prevTotals.files + 1n),
+      'total-delete-files': '0',
+      'total-position-deletes': '0',
+      'total-equality-deletes': '0',
+    },
+    'schema-id': metadata['current-schema-id'],
+  }
+  const parentId = metadata['current-snapshot-id']
+  if (parentId !== undefined) snapshot['parent-snapshot-id'] = parentId
+
+  // 5. Build and persist the new metadata
+  const priorMetadataLog = metadata['metadata-log'] ?? []
+  const currentVersion = priorMetadataLog.length + 1
+  const newVersion = currentVersion + 1
+  const currentMetadataPath = `${tableUrl}/metadata/v${currentVersion}.metadata.json`
+  const newMetadataPath = `${tableUrl}/metadata/v${newVersion}.metadata.json`
+
+  /** @type {TableMetadata} */
+  const newMetadata = {
+    ...metadata,
+    'last-sequence-number': Number(sequenceNumber),
+    'last-updated-ms': timestampMs,
+    'current-snapshot-id': snapshot['snapshot-id'],
+    snapshots: [...metadata.snapshots ?? [], snapshot],
+    'snapshot-log': [
+      ...metadata['snapshot-log'] ?? [],
+      { 'timestamp-ms': timestampMs, 'snapshot-id': snapshot['snapshot-id'] },
+    ],
+    'metadata-log': [
+      ...priorMetadataLog,
+      { 'timestamp-ms': metadata['last-updated-ms'], 'metadata-file': currentMetadataPath },
+    ],
+  }
+
+  const metaWriter = resolver.writer(translateS3Url(newMetadataPath))
+  metaWriter.appendBytes(new TextEncoder().encode(JSON.stringify(newMetadata, null, 2)))
+  metaWriter.finish()
+
+  // 6. version-hint last so partial writes don't surface a torn commit
+  const hintWriter = resolver.writer(translateS3Url(`${tableUrl}/version-hint.text`))
+  hintWriter.appendBytes(new TextEncoder().encode(String(newVersion)))
+  hintWriter.finish()
+
+  return newMetadata
+}
+
+/**
+ * @param {TableMetadata} metadata
+ * @returns {Snapshot|undefined}
+ */
+function currentSnapshot(metadata) {
+  const id = metadata['current-snapshot-id']
+  if (id === undefined) return undefined
+  return metadata.snapshots?.find(s => s['snapshot-id'] === id)
+}
+
+/**
+ * @param {TableMetadata} metadata
+ * @param {Resolver} resolver
+ * @returns {Promise<Manifest[]>}
+ */
+async function loadPriorManifests(metadata, resolver) {
+  const snap = currentSnapshot(metadata)
+  if (!snap?.['manifest-list']) return []
+  return /** @type {Manifest[]} */ (await fetchAvroRecords(snap['manifest-list'], resolver))
+}
+
+/**
+ * Generate a positive snapshot id that fits in a JS Number.
+ *
+ * @returns {bigint}
+ */
+function newSnapshotId() {
+  const arr = new BigInt64Array(1)
+  globalThis.crypto.getRandomValues(arr)
+  const masked = arr[0] & 0x1fffffffffffffn // 53 bits
+  return masked === 0n ? 1n : masked
+}

--- a/src/write/manifest-list.js
+++ b/src/write/manifest-list.js
@@ -1,0 +1,77 @@
+import { avroWrite } from '../avro/avro.write.js'
+
+/**
+ * @import {Writer} from 'hyparquet-writer'
+ * @import {AvroRecord, Manifest} from '../../src/types.js'
+ */
+
+/**
+ * Avro schema for a v2 manifest list entry. Field ids and order match the
+ * Iceberg v2 spec.
+ *
+ * @type {AvroRecord}
+ */
+const manifestFileSchema = {
+  type: 'record',
+  name: 'manifest_file',
+  fields: [
+    { name: 'manifest_path', type: 'string', 'field-id': 500 },
+    { name: 'manifest_length', type: 'long', 'field-id': 501 },
+    { name: 'partition_spec_id', type: 'int', 'field-id': 502 },
+    { name: 'content', type: 'int', 'field-id': 517 },
+    { name: 'sequence_number', type: 'long', 'field-id': 515 },
+    { name: 'min_sequence_number', type: 'long', 'field-id': 516 },
+    { name: 'added_snapshot_id', type: 'long', 'field-id': 503 },
+    { name: 'added_files_count', type: 'int', 'field-id': 504 },
+    { name: 'existing_files_count', type: 'int', 'field-id': 505 },
+    { name: 'deleted_files_count', type: 'int', 'field-id': 506 },
+    { name: 'added_rows_count', type: 'long', 'field-id': 512 },
+    { name: 'existing_rows_count', type: 'long', 'field-id': 513 },
+    { name: 'deleted_rows_count', type: 'long', 'field-id': 514 },
+    {
+      name: 'partitions',
+      type: ['null', { type: 'array', items: { type: 'record', name: 'r508', fields: [] } }],
+      default: null,
+      'field-id': 507,
+    },
+  ],
+}
+
+/**
+ * Write a v2 manifest list containing the given manifest entries.
+ *
+ * @param {object} options
+ * @param {Writer} options.writer
+ * @param {bigint} options.snapshotId
+ * @param {bigint} options.sequenceNumber
+ * @param {Manifest[]} options.manifests
+ */
+export function writeManifestList({ writer, snapshotId, sequenceNumber, manifests }) {
+  const records = manifests.map(m => ({
+    manifest_path: m.manifest_path,
+    manifest_length: m.manifest_length,
+    partition_spec_id: m.partition_spec_id,
+    content: m.content,
+    sequence_number: m.sequence_number ?? sequenceNumber,
+    min_sequence_number: m.min_sequence_number ?? sequenceNumber,
+    added_snapshot_id: m.added_snapshot_id,
+    added_files_count: m.added_files_count,
+    existing_files_count: m.existing_files_count,
+    deleted_files_count: m.deleted_files_count,
+    added_rows_count: m.added_rows_count,
+    existing_rows_count: m.existing_rows_count,
+    deleted_rows_count: m.deleted_rows_count,
+    partitions: [],
+  }))
+
+  avroWrite({
+    writer,
+    schema: manifestFileSchema,
+    records,
+    metadata: {
+      'format-version': '2',
+      'snapshot-id': String(snapshotId),
+      'sequence-number': String(sequenceNumber),
+    },
+  })
+}

--- a/src/write/manifest.js
+++ b/src/write/manifest.js
@@ -1,0 +1,95 @@
+import { avroWrite } from '../avro/avro.write.js'
+
+/**
+ * @import {Writer} from 'hyparquet-writer'
+ * @import {AvroRecord, DataFile, Schema} from '../../src/types.js'
+ */
+
+/**
+ * Avro schema for a v2 manifest entry with an unpartitioned data file.
+ * Field order and ids match the Iceberg v2 spec so other readers can parse it.
+ *
+ * @type {AvroRecord}
+ */
+const manifestEntrySchema = {
+  type: 'record',
+  name: 'manifest_entry',
+  fields: [
+    { name: 'status', type: 'int', 'field-id': 0 },
+    { name: 'snapshot_id', type: ['null', 'long'], default: null, 'field-id': 1 },
+    { name: 'sequence_number', type: ['null', 'long'], default: null, 'field-id': 3 },
+    { name: 'file_sequence_number', type: ['null', 'long'], default: null, 'field-id': 4 },
+    {
+      name: 'data_file',
+      'field-id': 2,
+      type: {
+        type: 'record',
+        name: 'r2',
+        fields: [
+          { name: 'content', type: 'int', 'field-id': 134 },
+          { name: 'file_path', type: 'string', 'field-id': 100 },
+          { name: 'file_format', type: 'string', 'field-id': 101 },
+          {
+            name: 'partition',
+            'field-id': 102,
+            type: { type: 'record', name: 'r102', fields: [] },
+          },
+          { name: 'record_count', type: 'long', 'field-id': 103 },
+          { name: 'file_size_in_bytes', type: 'long', 'field-id': 104 },
+          { name: 'sort_order_id', type: ['null', 'int'], default: null, 'field-id': 140 },
+        ],
+      },
+    },
+  ],
+}
+
+/**
+ * Iceberg schema-as-struct used for the data file's row layout. This is
+ * embedded in the manifest's avro file metadata under the "schema" key.
+ *
+ * @param {Schema} schema
+ * @returns {string}
+ */
+function icebergSchemaJson(schema) {
+  return JSON.stringify(schema)
+}
+
+/**
+ * Write a v2 data manifest containing a single ADDED entry for `dataFile`.
+ *
+ * @param {object} options
+ * @param {Writer} options.writer
+ * @param {Schema} options.schema - current table schema (embedded in metadata)
+ * @param {bigint} options.snapshotId
+ * @param {DataFile} options.dataFile
+ */
+export function writeDataManifest({ writer, schema, snapshotId, dataFile }) {
+  const record = {
+    status: 1,
+    snapshot_id: snapshotId,
+    sequence_number: null,
+    file_sequence_number: null,
+    data_file: {
+      content: dataFile.content,
+      file_path: dataFile.file_path,
+      file_format: dataFile.file_format.toUpperCase(),
+      partition: {},
+      record_count: dataFile.record_count,
+      file_size_in_bytes: dataFile.file_size_in_bytes,
+      sort_order_id: dataFile.sort_order_id ?? 0,
+    },
+  }
+
+  avroWrite({
+    writer,
+    schema: manifestEntrySchema,
+    records: [record],
+    metadata: {
+      'format-version': '2',
+      content: 'data',
+      schema: icebergSchemaJson(schema),
+      'partition-spec': '[]',
+      'partition-spec-id': '0',
+    },
+  })
+}

--- a/src/write/parquet.js
+++ b/src/write/parquet.js
@@ -1,0 +1,68 @@
+import { parquetWrite } from 'hyparquet-writer'
+import { sanitize } from '../utils.js'
+
+/**
+ * @import {Writer} from 'hyparquet-writer/src/types.js'
+ * @import {BasicType, ColumnSource} from 'hyparquet-writer/src/types.js'
+ * @import {DecodedArray} from 'hyparquet'
+ * @import {Field, Schema} from '../../src/types.js'
+ */
+
+/**
+ * Write iceberg records to parquet, embedding the iceberg schema in the
+ * parquet key/value metadata so that the read path can map field ids back to
+ * physical column names.
+ *
+ * @param {object} options
+ * @param {Writer} options.writer
+ * @param {Schema} options.schema
+ * @param {Record<string, any>[]} options.records
+ */
+export function writeParquet({ writer, schema, records }) {
+  const columnData = schema.fields.map(field => ({
+    name: sanitize(field.name),
+    data: extractColumn(records, field),
+    type: icebergTypeToParquet(field.type),
+    nullable: !field.required,
+  }))
+
+  parquetWrite({
+    writer,
+    columnData,
+    kvMetadata: [{ key: 'iceberg.schema', value: JSON.stringify(schema) }],
+  })
+}
+
+/**
+ * @param {Record<string, any>[]} records
+ * @param {Field} field
+ * @returns {DecodedArray}
+ */
+function extractColumn(records, field) {
+  const out = new Array(records.length)
+  for (let i = 0; i < records.length; i++) {
+    const v = records[i][field.name]
+    out[i] = v === undefined ? null : v
+  }
+  return out
+}
+
+/**
+ * @param {string} type
+ * @returns {BasicType}
+ */
+function icebergTypeToParquet(type) {
+  switch (type) {
+  case 'boolean': return 'BOOLEAN'
+  case 'int': return 'INT32'
+  case 'long': return 'INT64'
+  case 'float': return 'FLOAT'
+  case 'double': return 'DOUBLE'
+  case 'string': return 'STRING'
+  case 'binary': return 'BYTE_ARRAY'
+  case 'uuid': return 'UUID'
+  case 'timestamp':
+  case 'timestamptz': return 'TIMESTAMP'
+  default: throw new Error(`unsupported iceberg type: ${type}`)
+  }
+}

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -56,6 +56,30 @@ describe('createIceberg', () => {
 
   })
 
+  it('creates a table with a provided schema', async () => {
+    /** @type {Record<string, ByteWriter>} */
+    const writers = {}
+    const writer = vi.fn(path => {
+      writers[path] = new ByteWriter()
+      return writers[path]
+    })
+    const resolver = { reader: vi.fn(), writer }
+    /** @type {import('../src/types.js').Schema} */
+    const schema = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'id', required: true, type: 'long' },
+        { id: 2, name: 'name', required: false, type: 'string' },
+      ],
+    }
+    const metadata = await icebergCreate({ tableUrl, resolver, schema })
+
+    expect(metadata.schemas).toEqual([schema])
+    expect(metadata['last-column-id']).toBe(2)
+    expect(metadata['current-schema-id']).toBe(0)
+  })
+
   it('throws an error if tableUrl is not provided', async () => {
     const resolver = { reader: vi.fn(), writer: vi.fn() }
     await expect(icebergCreate({ tableUrl: '', resolver })).rejects.toThrow('tableUrl is required')

--- a/test/write/append.test.js
+++ b/test/write/append.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ByteWriter } from 'hyparquet-writer'
+import { icebergAppend } from '../../src/write/append.js'
+import { icebergCreate } from '../../src/create.js'
+import { icebergRead } from '../../src/read.js'
+
+/**
+ * @import {Resolver, Schema} from '../../src/types.js'
+ */
+
+/**
+ * Create an in-memory resolver pair backed by a single map.
+ * The writer captures bytes per path; the reader serves them back as AsyncBuffer.
+ *
+ * @returns {{ resolver: Resolver, files: Map<string, Uint8Array> }}
+ */
+function memResolver() {
+  /** @type {Map<string, Uint8Array>} */
+  const files = new Map()
+  /** @type {Resolver} */
+  const resolver = {
+    reader(path) {
+      const bytes = files.get(path)
+      if (!bytes) throw new Error(`no such file: ${path}`)
+      const ab = /** @type {ArrayBuffer} */ (
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+      )
+      return {
+        byteLength: bytes.byteLength,
+        slice: (/** @type {number} */ s, /** @type {number} */ e) => ab.slice(s, e),
+      }
+    },
+    writer(path) {
+      const w = new ByteWriter()
+      const origFinish = w.finish.bind(w)
+      w.finish = () => {
+        origFinish()
+        files.set(path, w.getBytes())
+      }
+      return w
+    },
+  }
+  return { resolver, files }
+}
+
+describe('icebergAppend', () => {
+  /** @type {Schema} */
+  const schema = {
+    type: 'struct',
+    'schema-id': 0,
+    fields: [
+      { id: 1, name: 'id', required: true, type: 'long' },
+      { id: 2, name: 'name', required: false, type: 'string' },
+    ],
+  }
+
+  it('appends a snapshot that round-trips through icebergRead', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+    // use a non-s3 url so translateS3Url is a no-op
+    const tableUrl = 'http://test/table'
+    const { resolver } = memResolver()
+
+    const created = await icebergCreate({ tableUrl, resolver, schema })
+
+    const records = [
+      { id: 1n, name: 'alice' },
+      { id: 2n, name: 'bob' },
+    ]
+    const v2 = await icebergAppend({ tableUrl, metadata: created, records, resolver })
+
+    expect(v2['current-snapshot-id']).toBeGreaterThan(0)
+    expect(v2['last-sequence-number']).toBe(1)
+    expect(v2.snapshots).toHaveLength(1)
+    expect(v2.snapshots?.[0].summary).toMatchObject({
+      operation: 'append',
+      'added-records': '2',
+      'total-records': '2',
+      'total-data-files': '1',
+    })
+
+    const read = await icebergRead({ tableUrl, metadata: v2, resolver })
+    expect(read).toEqual(records)
+  })
+
+  it('supports a second append carrying forward prior manifests', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+    const tableUrl = 'http://test/table2'
+    const { resolver } = memResolver()
+
+    const created = await icebergCreate({ tableUrl, resolver, schema })
+    const v2 = await icebergAppend({
+      tableUrl, metadata: created, resolver,
+      records: [{ id: 1n, name: 'alice' }],
+    })
+    const v3 = await icebergAppend({
+      tableUrl, metadata: v2, resolver,
+      records: [{ id: 2n, name: 'bob' }, { id: 3n, name: 'carol' }],
+    })
+
+    expect(v3.snapshots).toHaveLength(2)
+    expect(v3['last-sequence-number']).toBe(2)
+    expect(v3.snapshots?.[1].summary['total-records']).toBe('3')
+    expect(v3.snapshots?.[1]['parent-snapshot-id']).toBe(v2['current-snapshot-id'])
+
+    const read = await icebergRead({ tableUrl, metadata: v3, resolver })
+    expect(read).toEqual([
+      { id: 2n, name: 'bob' },
+      { id: 3n, name: 'carol' },
+      { id: 1n, name: 'alice' },
+    ])
+  })
+
+  it('throws if resolver.writer is missing', async () => {
+    const tableUrl = 'http://test/table3'
+    /** @type {Resolver} */
+    const resolver = {
+      reader() { throw new Error('unused') },
+    }
+    await expect(icebergAppend({
+      tableUrl,
+      metadata: /** @type {any} */ ({ 'format-version': 2 }),
+      records: [],
+      resolver,
+    })).rejects.toThrow('resolver.writer is required')
+  })
+})

--- a/test/write/manifest-list.test.js
+++ b/test/write/manifest-list.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { ByteWriter } from 'hyparquet-writer'
+import { writeManifestList } from '../../src/write/manifest-list.js'
+import { avroMetadata } from '../../src/avro/avro.metadata.js'
+import { avroRead } from '../../src/avro/avro.read.js'
+
+/**
+ * @import {Manifest} from '../../src/types.js'
+ */
+
+describe('writeManifestList', () => {
+  it('round-trips a single manifest entry', async () => {
+    /** @type {Manifest} */
+    const manifest = {
+      manifest_path: 's3://bucket/table/metadata/m0.avro',
+      manifest_length: 1234n,
+      partition_spec_id: 0,
+      content: 0,
+      added_snapshot_id: 999n,
+      added_files_count: 1,
+      existing_files_count: 0,
+      deleted_files_count: 0,
+      added_rows_count: 3n,
+      existing_rows_count: 0n,
+      deleted_rows_count: 0n,
+    }
+    const writer = new ByteWriter()
+    writeManifestList({
+      writer,
+      snapshotId: 999n,
+      sequenceNumber: 1n,
+      manifests: [manifest],
+    })
+    const buffer = writer.getBuffer()
+
+    const reader = { view: new DataView(buffer), offset: 0 }
+    const { metadata, syncMarker } = await avroMetadata(reader)
+    expect(metadata['format-version']).toBe('2')
+    expect(metadata['snapshot-id']).toBe('999')
+    expect(metadata['sequence-number']).toBe('1')
+
+    const records = await avroRead({ reader, metadata, syncMarker })
+    expect(records).toHaveLength(1)
+    expect(records[0]).toMatchObject({
+      manifest_path: 's3://bucket/table/metadata/m0.avro',
+      manifest_length: 1234n,
+      partition_spec_id: 0,
+      content: 0,
+      sequence_number: 1n,
+      min_sequence_number: 1n,
+      added_snapshot_id: 999n,
+      added_files_count: 1,
+      existing_files_count: 0,
+      deleted_files_count: 0,
+      added_rows_count: 3n,
+      existing_rows_count: 0n,
+      deleted_rows_count: 0n,
+    })
+  })
+})

--- a/test/write/manifest.test.js
+++ b/test/write/manifest.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { ByteWriter } from 'hyparquet-writer'
+import { writeDataManifest } from '../../src/write/manifest.js'
+import { avroMetadata } from '../../src/avro/avro.metadata.js'
+import { avroRead } from '../../src/avro/avro.read.js'
+
+/**
+ * @import {DataFile, Schema} from '../../src/types.js'
+ */
+
+describe('writeDataManifest', () => {
+  /** @type {Schema} */
+  const schema = {
+    type: 'struct',
+    'schema-id': 0,
+    fields: [
+      { id: 1, name: 'id', required: true, type: 'long' },
+      { id: 2, name: 'name', required: false, type: 'string' },
+    ],
+  }
+
+  /** @type {DataFile} */
+  const dataFile = {
+    content: 0,
+    file_path: 's3://bucket/table/data/abc.parquet',
+    file_format: 'parquet',
+    partition: {},
+    record_count: 3n,
+    file_size_in_bytes: 421n,
+    sort_order_id: 0,
+  }
+
+  it('writes a manifest that round-trips through the avro reader', async () => {
+    const writer = new ByteWriter()
+    writeDataManifest({ writer, schema, snapshotId: 12345n, dataFile })
+    const buffer = writer.getBuffer()
+
+    const reader = { view: new DataView(buffer), offset: 0 }
+    const { metadata, syncMarker } = await avroMetadata(reader)
+    expect(metadata['format-version']).toBe('2')
+    expect(metadata.content).toBe('data')
+    expect(metadata['partition-spec']).toBe('[]')
+    expect(metadata['partition-spec-id']).toBe('0')
+    expect(metadata.schema).toEqual(schema)
+
+    const records = await avroRead({ reader, metadata, syncMarker })
+    expect(records).toHaveLength(1)
+    expect(records[0]).toMatchObject({
+      status: 1,
+      snapshot_id: 12345n,
+      data_file: {
+        content: 0,
+        file_path: 's3://bucket/table/data/abc.parquet',
+        file_format: 'PARQUET',
+        partition: {},
+        record_count: 3n,
+        file_size_in_bytes: 421n,
+        sort_order_id: 0,
+      },
+    })
+  })
+})

--- a/test/write/parquet.test.js
+++ b/test/write/parquet.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { ByteWriter } from 'hyparquet-writer'
+import { parquetMetadata, parquetReadObjects } from 'hyparquet'
+import { compressors } from 'hyparquet-compressors'
+import { writeParquet } from '../../src/write/parquet.js'
+
+/**
+ * @import {Schema} from '../../src/types.js'
+ */
+
+describe('writeParquet', () => {
+  /** @type {Schema} */
+  const schema = {
+    type: 'struct',
+    'schema-id': 0,
+    fields: [
+      { id: 1, name: 'id', required: true, type: 'long' },
+      { id: 2, name: 'Name', required: false, type: 'string' },
+      { id: 3, name: 'score', required: false, type: 'double' },
+    ],
+  }
+  const records = [
+    { id: 1n, Name: 'alice', score: 1.5 },
+    { id: 2n, Name: 'bob', score: 2.5 },
+    { id: 3n, Name: null, score: null },
+  ]
+
+  it('round-trips records and embeds iceberg.schema', async () => {
+    const writer = new ByteWriter()
+    writeParquet({ writer, schema, records })
+    const file = writer.getBuffer()
+
+    const meta = parquetMetadata(file)
+    const kv = meta.key_value_metadata?.find(k => k.key === 'iceberg.schema')
+    expect(kv).toBeDefined()
+    expect(JSON.parse(kv?.value ?? '')).toEqual(schema)
+
+    const rows = await parquetReadObjects({ file, compressors })
+    expect(rows).toEqual([
+      { id: 1n, Name: 'alice', score: 1.5 },
+      { id: 2n, Name: 'bob', score: 2.5 },
+      { id: 3n, Name: null, score: null },
+    ])
+  })
+
+  it('throws on unsupported type', () => {
+    const writer = new ByteWriter()
+    /** @type {Schema} */
+    const bad = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [{ id: 1, name: 'x', required: false, type: 'decimal(9,2)' }],
+    }
+    expect(() => writeParquet({ writer, schema: bad, records: [] }))
+      .toThrow('unsupported iceberg type: decimal(9,2)')
+  })
+})


### PR DESCRIPTION
## Summary
- Add `icebergAppend` for v2 unpartitioned tables: writes a parquet data file, manifest, manifest list, new `vN+1.metadata.json`, and updates `version-hint.text`. Supports first append and subsequent appends (carries prior manifests forward and links `parent-snapshot-id`).
- Add `writeParquet` that embeds the iceberg schema as `iceberg.schema` parquet kv metadata so the read path can map field ids back to physical column names.
- Add `writeDataManifest` and `writeManifestList` for v2 unpartitioned Avro outputs, including the iceberg-required file-level metadata (`format-version`, `content`, `schema`, `partition-spec`, `partition-spec-id`).
- Extend `avroWrite` to accept extra file-level metadata.

## Out of scope (follow-ups)
- Partitioned writes, sort-on-write, deletes/updates, schema evolution.
- Per-file column statistics (lower/upper bounds, null/value/nan counts).
- Atomic commit (conditional PUT / If-None-Match) and retry-on-conflict.
- REST catalog `commit-table`.
