### PR TITLE
Add per-column stats to data manifest entries

### DIFF
--- a/src/avro/avro.write.js
+++ b/src/avro/avro.write.js
@@ -61,8 +61,12 @@ function writeType(writer, schema, value) {
     const unionIndex = schema.findIndex(s => {
       if (Array.isArray(s)) throw new Error('nested unions not supported')
 
-      // normalise branch to a tag string we can test against
-      const tag = typeof s === 'string' ? s : 'logicalType' in s ? s.logicalType : s.type
+      // normalise branch to a tag string we can test against. For complex
+      // types (record/array) the structural type wins over any logicalType
+      // annotation (e.g. an Iceberg array with logicalType=map is still an array).
+      const tag = typeof s === 'string' ? s
+        : s.type === 'record' || s.type === 'array' ? s.type
+          : s.logicalType
 
       if (value == null) return tag === 'null'
       if (tag === 'boolean') return typeof value === 'boolean'
@@ -109,6 +113,18 @@ function writeType(writer, schema, value) {
       appendZigZag(writer, b.length)
       writer.appendBytes(b)
     }
+  } else if (schema.type === 'record') {
+    for (const f of schema.fields) {
+      writeType(writer, f.type, value[f.name])
+    }
+  } else if (schema.type === 'array') {
+    if (value.length) {
+      appendZigZag(writer, value.length)
+      for (const it of value) {
+        writeType(writer, schema.items, it)
+      }
+    }
+    writer.appendVarInt(0)
   } else if ('logicalType' in schema) {
     if (schema.logicalType === 'date') {
       appendZigZag(writer, value instanceof Date ? Math.floor(value.getTime() / 86400000) : value)
@@ -135,18 +151,6 @@ function writeType(writer, schema, value) {
     } else {
       throw new Error(`unknown logical type ${schema.logicalType}`)
     }
-  } else if (schema.type === 'record') {
-    for (const f of schema.fields) {
-      writeType(writer, f.type, value[f.name])
-    }
-  } else if (schema.type === 'array') {
-    if (value.length) {
-      appendZigZag(writer, value.length)
-      for (const it of value) {
-        writeType(writer, schema.items, it)
-      }
-    }
-    writer.appendVarInt(0)
   } else {
     throw new Error(`unknown schema type ${JSON.stringify(schema)}`)
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -246,6 +246,7 @@ interface AvroArray {
   type: 'array'
   items: AvroType
   default?: any[]
+  logicalType?: 'map' // Iceberg map-as-array annotation for non-string keys
 }
 
 type AvroUnion = AvroType[]

--- a/src/write/append.js
+++ b/src/write/append.js
@@ -3,6 +3,7 @@ import { uuid4 } from '../utils.js'
 import { writeParquet } from './parquet.js'
 import { writeDataManifest } from './manifest.js'
 import { writeManifestList } from './manifest-list.js'
+import { computeColumnStats } from './stats.js'
 
 /**
  * @import {Resolver, Manifest, Schema, Snapshot, TableMetadata} from '../../src/types.js'
@@ -49,6 +50,7 @@ export async function icebergAppend({ tableUrl, metadata, records, resolver }) {
   const dataFileSize = BigInt(dataWriter.offset)
 
   // 2. Write manifest
+  const stats = computeColumnStats(records, schema)
   const manifestPath = `${tableUrl}/metadata/${manifestUuid}-m0.avro`
   const manifestWriter = resolver.writer(translateS3Url(manifestPath))
   writeDataManifest({
@@ -62,6 +64,11 @@ export async function icebergAppend({ tableUrl, metadata, records, resolver }) {
       partition: {},
       record_count: BigInt(records.length),
       file_size_in_bytes: dataFileSize,
+      value_counts: stats.value_counts,
+      null_value_counts: stats.null_value_counts,
+      nan_value_counts: stats.nan_value_counts,
+      lower_bounds: stats.lower_bounds,
+      upper_bounds: stats.upper_bounds,
       sort_order_id: 0,
     },
   })

--- a/src/write/manifest.js
+++ b/src/write/manifest.js
@@ -36,11 +36,49 @@ const manifestEntrySchema = {
           },
           { name: 'record_count', type: 'long', 'field-id': 103 },
           { name: 'file_size_in_bytes', type: 'long', 'field-id': 104 },
+          mapField('column_sizes', 108, 'k117_v118', 117, 118, 'long'),
+          mapField('value_counts', 109, 'k119_v120', 119, 120, 'long'),
+          mapField('null_value_counts', 110, 'k121_v122', 121, 122, 'long'),
+          mapField('nan_value_counts', 137, 'k138_v139', 138, 139, 'long'),
+          mapField('lower_bounds', 125, 'k126_v127', 126, 127, 'bytes'),
+          mapField('upper_bounds', 128, 'k129_v130', 129, 130, 'bytes'),
           { name: 'sort_order_id', type: ['null', 'int'], default: null, 'field-id': 140 },
         ],
       },
     },
   ],
+}
+
+/**
+ * Build a nullable Avro array-of-{key,value}-records field with the
+ * Iceberg "logical-type": "map" annotation.
+ *
+ * @param {string} name
+ * @param {number} fieldId
+ * @param {string} recName
+ * @param {number} keyId
+ * @param {number} valueId
+ * @param {'long'|'bytes'} valueType
+ * @returns {import('../../src/types.js').AvroField}
+ */
+function mapField(name, fieldId, recName, keyId, valueId, valueType) {
+  return {
+    name,
+    'field-id': fieldId,
+    default: null,
+    type: ['null', {
+      type: 'array',
+      logicalType: 'map',
+      items: {
+        type: 'record',
+        name: recName,
+        fields: [
+          { name: 'key', type: 'int', 'field-id': keyId },
+          { name: 'value', type: valueType, 'field-id': valueId },
+        ],
+      },
+    }],
+  }
 }
 
 /**
@@ -52,6 +90,21 @@ const manifestEntrySchema = {
  */
 function icebergSchemaJson(schema) {
   return JSON.stringify(schema)
+}
+
+/**
+ * Encode an Iceberg stat map as an Avro array of {key, value} records,
+ * or null if the input has no entries.
+ *
+ * @template V
+ * @param {Record<number, V>|undefined} m
+ * @returns {{key: number, value: V}[]|null}
+ */
+function encodeMap(m) {
+  if (!m) return null
+  const entries = Object.entries(m)
+  if (!entries.length) return null
+  return entries.map(([k, value]) => ({ key: Number(k), value }))
 }
 
 /**
@@ -76,6 +129,12 @@ export function writeDataManifest({ writer, schema, snapshotId, dataFile }) {
       partition: {},
       record_count: dataFile.record_count,
       file_size_in_bytes: dataFile.file_size_in_bytes,
+      column_sizes: encodeMap(dataFile.column_sizes),
+      value_counts: encodeMap(dataFile.value_counts),
+      null_value_counts: encodeMap(dataFile.null_value_counts),
+      nan_value_counts: encodeMap(dataFile.nan_value_counts),
+      lower_bounds: encodeMap(dataFile.lower_bounds),
+      upper_bounds: encodeMap(dataFile.upper_bounds),
       sort_order_id: dataFile.sort_order_id ?? 0,
     },
   }

--- a/src/write/stats.js
+++ b/src/write/stats.js
@@ -1,0 +1,194 @@
+/**
+ * @import {Field, Schema} from '../../src/types.js'
+ */
+
+/**
+ * Compute per-column statistics for a batch of records.
+ *
+ * Returns the optional stat maps used in a manifest entry's data_file
+ * (value_counts, null_value_counts, nan_value_counts, lower_bounds,
+ * upper_bounds), keyed by field id. Bounds are serialized per the Iceberg
+ * single-value serialization spec; columns whose type lacks a serializer
+ * are omitted from the bounds maps.
+ *
+ * @param {Record<string, any>[]} records
+ * @param {Schema} schema
+ * @returns {{
+ *   value_counts: Record<number, bigint>,
+ *   null_value_counts: Record<number, bigint>,
+ *   nan_value_counts: Record<number, bigint>,
+ *   lower_bounds: Record<number, Uint8Array>,
+ *   upper_bounds: Record<number, Uint8Array>,
+ * }}
+ */
+export function computeColumnStats(records, schema) {
+  /** @type {Record<number, bigint>} */
+  const value_counts = {}
+  /** @type {Record<number, bigint>} */
+  const null_value_counts = {}
+  /** @type {Record<number, bigint>} */
+  const nan_value_counts = {}
+  /** @type {Record<number, Uint8Array>} */
+  const lower_bounds = {}
+  /** @type {Record<number, Uint8Array>} */
+  const upper_bounds = {}
+
+  for (const field of schema.fields) {
+    let nulls = 0n
+    let nans = 0n
+    let min
+    let max
+    const isFloat = field.type === 'float' || field.type === 'double'
+    for (const record of records) {
+      const v = record[field.name]
+      if (v === null || v === undefined) {
+        nulls++
+        continue
+      }
+      if (isFloat && Number.isNaN(v)) {
+        nans++
+        continue
+      }
+      if (min === undefined || compare(v, min, field) < 0) min = v
+      if (max === undefined || compare(v, max, field) > 0) max = v
+    }
+    value_counts[field.id] = BigInt(records.length)
+    null_value_counts[field.id] = nulls
+    if (isFloat) nan_value_counts[field.id] = nans
+    if (min !== undefined) {
+      const lo = serializeValue(min, field)
+      if (lo) lower_bounds[field.id] = lo
+    }
+    if (max !== undefined) {
+      const hi = serializeValue(max, field)
+      if (hi) upper_bounds[field.id] = hi
+    }
+  }
+
+  return { value_counts, null_value_counts, nan_value_counts, lower_bounds, upper_bounds }
+}
+
+/**
+ * Compare two non-null values of the given iceberg type.
+ *
+ * @param {any} a
+ * @param {any} b
+ * @param {Field} field
+ * @returns {number}
+ */
+function compare(a, b, field) {
+  switch (field.type) {
+  case 'boolean':
+    return (a ? 1 : 0) - (b ? 1 : 0)
+  case 'int':
+  case 'float':
+  case 'double':
+    return a < b ? -1 : a > b ? 1 : 0
+  case 'long':
+  case 'timestamp':
+  case 'timestamptz': {
+    const ai = typeof a === 'bigint' ? a : BigInt(a)
+    const bi = typeof b === 'bigint' ? b : BigInt(b)
+    return ai < bi ? -1 : ai > bi ? 1 : 0
+  }
+  case 'string':
+    return a < b ? -1 : a > b ? 1 : 0
+  case 'binary':
+  case 'uuid':
+    return compareBytes(a, b)
+  default:
+    return a < b ? -1 : a > b ? 1 : 0
+  }
+}
+
+/**
+ * Lexicographic unsigned-byte comparison.
+ *
+ * @param {Uint8Array} a
+ * @param {Uint8Array} b
+ * @returns {number}
+ */
+function compareBytes(a, b) {
+  const len = Math.min(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i]
+  }
+  return a.length - b.length
+}
+
+/**
+ * Serialize a value per the Iceberg single-value serialization spec.
+ * Returns undefined for types we don't yet support so the bound is omitted.
+ *
+ * @param {any} value
+ * @param {Field} field
+ * @returns {Uint8Array|undefined}
+ */
+function serializeValue(value, field) {
+  switch (field.type) {
+  case 'boolean': {
+    return new Uint8Array([value ? 1 : 0])
+  }
+  case 'int': {
+    const buf = new ArrayBuffer(4)
+    new DataView(buf).setInt32(0, value, true)
+    return new Uint8Array(buf)
+  }
+  case 'long': {
+    const buf = new ArrayBuffer(8)
+    new DataView(buf).setBigInt64(0, typeof value === 'bigint' ? value : BigInt(value), true)
+    return new Uint8Array(buf)
+  }
+  case 'float': {
+    const buf = new ArrayBuffer(4)
+    new DataView(buf).setFloat32(0, value, true)
+    return new Uint8Array(buf)
+  }
+  case 'double': {
+    const buf = new ArrayBuffer(8)
+    new DataView(buf).setFloat64(0, value, true)
+    return new Uint8Array(buf)
+  }
+  case 'timestamp':
+  case 'timestamptz': {
+    // micros since epoch, 8-byte little-endian
+    const micros = typeof value === 'bigint' ? value
+      : value instanceof Date ? BigInt(value.getTime()) * 1000n
+        : BigInt(value)
+    const buf = new ArrayBuffer(8)
+    new DataView(buf).setBigInt64(0, micros, true)
+    return new Uint8Array(buf)
+  }
+  case 'string': {
+    return new TextEncoder().encode(value)
+  }
+  case 'binary': {
+    return value instanceof Uint8Array ? value : undefined
+  }
+  case 'uuid': {
+    if (value instanceof Uint8Array && value.length === 16) return value
+    if (typeof value === 'string') return uuidStringToBytes(value)
+    return undefined
+  }
+  default:
+    return undefined
+  }
+}
+
+/**
+ * Parse a canonical UUID string to its 16 big-endian bytes.
+ *
+ * @param {string} s
+ * @returns {Uint8Array|undefined}
+ */
+function uuidStringToBytes(s) {
+  const hex = s.replace(/-/g, '')
+  if (hex.length !== 32) return undefined
+  const out = new Uint8Array(16)
+  for (let i = 0; i < 16; i++) {
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+    if (Number.isNaN(byte)) return undefined
+    out[i] = byte
+  }
+  return out
+}

--- a/test/write/manifest.test.js
+++ b/test/write/manifest.test.js
@@ -27,6 +27,10 @@ describe('writeDataManifest', () => {
     partition: {},
     record_count: 3n,
     file_size_in_bytes: 421n,
+    value_counts: { 1: 3n, 2: 3n },
+    null_value_counts: { 1: 0n, 2: 1n },
+    lower_bounds: { 1: new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]) },
+    upper_bounds: { 1: new Uint8Array([5, 0, 0, 0, 0, 0, 0, 0]) },
     sort_order_id: 0,
   }
 
@@ -58,5 +62,24 @@ describe('writeDataManifest', () => {
         sort_order_id: 0,
       },
     })
+
+    // Stat maps round-trip as Avro array-of-{key,value} records
+    const df = records[0].data_file
+    expect(df.value_counts).toEqual([
+      { key: 1, value: 3n },
+      { key: 2, value: 3n },
+    ])
+    expect(df.null_value_counts).toEqual([
+      { key: 1, value: 0n },
+      { key: 2, value: 1n },
+    ])
+    expect(df.lower_bounds).toEqual([
+      { key: 1, value: new Uint8Array([1, 0, 0, 0, 0, 0, 0, 0]) },
+    ])
+    expect(df.upper_bounds).toEqual([
+      { key: 1, value: new Uint8Array([5, 0, 0, 0, 0, 0, 0, 0]) },
+    ])
+    expect(df.nan_value_counts).toBeUndefined()
+    expect(df.column_sizes).toBeUndefined()
   })
 })

--- a/test/write/stats.test.js
+++ b/test/write/stats.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { computeColumnStats } from '../../src/write/stats.js'
+
+/**
+ * @import {Schema} from '../../src/types.js'
+ */
+
+describe('computeColumnStats', () => {
+  it('counts nulls and bounds for primitive columns', () => {
+    /** @type {Schema} */
+    const schema = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'id', required: true, type: 'long' },
+        { id: 2, name: 'name', required: false, type: 'string' },
+      ],
+    }
+    const records = [
+      { id: 1n, name: 'banana' },
+      { id: 5n, name: null },
+      { id: 3n, name: 'apple' },
+    ]
+
+    const stats = computeColumnStats(records, schema)
+
+    expect(stats.value_counts).toEqual({ 1: 3n, 2: 3n })
+    expect(stats.null_value_counts).toEqual({ 1: 0n, 2: 1n })
+    expect(stats.nan_value_counts).toEqual({})
+
+    // long: 8-byte little-endian
+    const lo = new DataView(stats.lower_bounds[1].buffer).getBigInt64(0, true)
+    const hi = new DataView(stats.upper_bounds[1].buffer).getBigInt64(0, true)
+    expect(lo).toBe(1n)
+    expect(hi).toBe(5n)
+
+    // string: utf-8 bytes
+    expect(new TextDecoder().decode(stats.lower_bounds[2])).toBe('apple')
+    expect(new TextDecoder().decode(stats.upper_bounds[2])).toBe('banana')
+  })
+
+  it('counts NaNs and excludes them from bounds for floats', () => {
+    /** @type {Schema} */
+    const schema = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 7, name: 'score', required: false, type: 'double' },
+      ],
+    }
+    const records = [
+      { score: 1.5 },
+      { score: NaN },
+      { score: -2.25 },
+      { score: null },
+    ]
+
+    const stats = computeColumnStats(records, schema)
+
+    expect(stats.value_counts[7]).toBe(4n)
+    expect(stats.null_value_counts[7]).toBe(1n)
+    expect(stats.nan_value_counts[7]).toBe(1n)
+
+    const lo = new DataView(stats.lower_bounds[7].buffer).getFloat64(0, true)
+    const hi = new DataView(stats.upper_bounds[7].buffer).getFloat64(0, true)
+    expect(lo).toBe(-2.25)
+    expect(hi).toBe(1.5)
+  })
+
+  it('omits bounds when all values are null', () => {
+    /** @type {Schema} */
+    const schema = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'x', required: false, type: 'int' },
+      ],
+    }
+    const stats = computeColumnStats([{ x: null }, { x: null }], schema)
+    expect(stats.value_counts[1]).toBe(2n)
+    expect(stats.null_value_counts[1]).toBe(2n)
+    expect(stats.lower_bounds).toEqual({})
+    expect(stats.upper_bounds).toEqual({})
+  })
+})


### PR DESCRIPTION
- New `src/write/stats.js` — `computeColumnStats(records, schema)` returns `value_counts`, `null_value_counts`, `nan_value_counts`, and `lower_bounds`/`upper_bounds` keyed by field id, with bounds serialized per the Iceberg single-value spec (boolean, int, long, float, double, string, binary, uuid, timestamp, timestamptz)
- Extended the manifest entry's `data_file` Avro schema in `src/write/manifest.js` with the optional stat map fields using the spec's field ids (108/109/110/137/125/128) and `kNNN_vNNN` key/value records, annotated with `"logicalType": "map"`
- `icebergAppend` now computes stats from the records being written and threads them through `writeDataManifest`
- Fixed an ordering bug in `src/avro/avro.write.js` exposed by the new `logicalType: 'map'` annotation: union-branch detection and the type dispatch were checking `'logicalType' in schema` before the structural type, so arrays-with-logicalType got misrouted; now `record`/`array` win
- Added `logicalType?: 'map'` to the `AvroArray` type in `src/types.d.ts`
- `column_sizes` and `split_offsets` left out — they need parquet internals hyparquet-writer doesn't currently expose
- Tests: new `stats.test.js` covering nulls/bounds, NaN handling, and all-null columns; `manifest.test.js` extended to assert stat maps round-trip through `avroRead`
