### PR TITLE
V3 Row lineage

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -72,9 +72,31 @@ async function fetchManifests(manifests, resolver) {
         }
       }
     }
+    assignFirstRowIds(manifest, entries)
 
     return { url, entries }
   }))
+}
+
+/**
+ * Apply v3 first-row-id inheritance from the manifest list into data file
+ * entries. Delete files never inherit row IDs.
+ *
+ * @param {Manifest} manifest
+ * @param {ManifestEntry[]} entries
+ */
+function assignFirstRowIds(manifest, entries) {
+  if (manifest.content !== 0 || manifest.first_row_id == null) return
+
+  let nextFirstRowId = BigInt(manifest.first_row_id)
+  for (const entry of entries) {
+    const dataFile = entry.data_file
+    if (dataFile.content !== 0) continue
+    if (dataFile.first_row_id == null) {
+      dataFile.first_row_id = nextFirstRowId
+      nextFirstRowId += BigInt(dataFile.record_count)
+    }
+  }
 }
 
 /**

--- a/src/read.js
+++ b/src/read.js
@@ -9,7 +9,7 @@ import { equalityMatch, sanitize } from './utils.js'
  * Reads data from the Iceberg table with optional row-level delete processing.
  * Row indices are zero-based and rowEnd is exclusive.
  *
- * @import {Resolver, Lister} from '../src/types.js'
+ * @import {Lister, NameMapping, Resolver, Schema, TableMetadata} from '../src/types.js'
  * @param {object} options
  * @param {string} options.tableUrl - Base URL or path of the table.
  * @param {number} [options.rowStart] - The starting global row index to fetch (inclusive).
@@ -44,6 +44,7 @@ export async function icebergRead({
   const currentSchemaId = metadata['current-schema-id']
   const schema = metadata.schemas.find(s => s['schema-id'] === currentSchemaId)
   if (!schema) throw new Error('current schema not found in metadata')
+  const rowLineage = metadata['format-version'] >= 3
 
   // Get manifest URLs for data and delete files
   const { dataEntries, deleteEntries } = splitManifestEntries(manifestList)
@@ -108,22 +109,31 @@ export async function icebergRead({
         parquetColumnNames.push(undefined)
       }
     }
+    const lineageColumns = rowLineage ? rowLineageColumnNames(parquetIcebergSchema) : {}
+    const columns = parquetColumnNames.filter(n => n !== undefined)
+    for (const column of [lineageColumns.rowId, lineageColumns.lastUpdatedSequenceNumber]) {
+      if (column && !columns.includes(column)) columns.push(column)
+    }
 
-    let rows = await parquetReadObjects({
+    const rows = await parquetReadObjects({
       file: asyncBuffer,
       metadata: parquetMetadata,
-      columns: parquetColumnNames.filter(n => n !== undefined),
+      columns,
       rowStart: fileRowStart,
       rowEnd: fileRowEnd,
       compressors,
     })
+    let rowEntries = rows.map((row, idx) => ({
+      row,
+      pos: BigInt(fileRowStart + idx),
+    }))
 
     // If delete files apply to this data file, filter the rows
     const { positionDeletesMap, equalityDeletesMap } = await deleteMaps
 
     const positionDeletes = positionDeletesMap.get(data_file.file_path)
     if (positionDeletes) {
-      rows = rows.filter((_, idx) => !positionDeletes.has(BigInt(idx + fileRowStart)))
+      rowEntries = rowEntries.filter(entry => !positionDeletes.has(entry.pos))
     }
     for (const [deleteSequenceNumber, deleteRows] of equalityDeletesMap) {
       // An equality delete file must be applied to a data file when all of the following are true:
@@ -137,11 +147,11 @@ export async function icebergRead({
       //   when the data and delete file data sequence numbers are equal.
       //   This allows deleting rows that were added in the same commit.
       if (deleteSequenceNumber <= sequence_number) continue // Skip deletes that are too old
-      rows = rows.filter(row => !deleteRows.some(predicate => equalityMatch(row, predicate)))
+      rowEntries = rowEntries.filter(({ row }) => !deleteRows.some(predicate => equalityMatch(row, predicate)))
     }
 
     // Map parquet column names to iceberg names by field id
-    for (const row of rows) {
+    for (const { row, pos } of rowEntries) {
       /** @type {Record<string, any>} */
       const out = {}
       for (let i = 0; i < schema.fields.length; i++) {
@@ -188,11 +198,21 @@ export async function icebergRead({
           }
         }
       }
+      if (rowLineage) {
+        applyRowLineage(out, {
+          row,
+          pos,
+          firstRowId: data_file.first_row_id,
+          sequenceNumber: sequence_number,
+          rowIdColumn: lineageColumns.rowId,
+          lastUpdatedSequenceNumberColumn: lineageColumns.lastUpdatedSequenceNumber,
+        })
+      }
       results.push(out)
     }
 
     if (rowsNeeded !== Infinity) {
-      rowsNeeded -= rows.length
+      rowsNeeded -= rowEntries.length
       if (rowsNeeded <= 0) break
     }
   }
@@ -203,7 +223,6 @@ export async function icebergRead({
 /**
  * Recursively find the name mapping object that belongs to a particular field‑id.
  *
- * @import {TableMetadata, NameMapping} from '../src/types.js'
  * @param {NameMapping[]} mappings
  * @param {number} fieldId
  * @returns {NameMapping|undefined}
@@ -215,5 +234,65 @@ function nameMappingById(mappings, fieldId) {
       const hit = nameMappingById(m.fields, fieldId)
       if (hit) return hit
     }
+  }
+}
+
+/**
+ * @param {Schema} parquetIcebergSchema
+ * @returns {{rowId?: string, lastUpdatedSequenceNumber?: string}}
+ */
+function rowLineageColumnNames(parquetIcebergSchema) {
+  return {
+    rowId: columnNameByFieldId(parquetIcebergSchema, 2147483540),
+    lastUpdatedSequenceNumber: columnNameByFieldId(parquetIcebergSchema, 2147483539),
+  }
+}
+
+/**
+ * @param {Schema} schema
+ * @param {number} fieldId
+ * @returns {string|undefined}
+ */
+function columnNameByFieldId(schema, fieldId) {
+  const field = schema.fields.find(f => f.id === fieldId)
+  return field ? sanitize(field.name) : undefined
+}
+
+/**
+ * @param {Record<string, any>} out
+ * @param {object} options
+ * @param {Record<string, any>} options.row
+ * @param {bigint} options.pos
+ * @param {bigint | number | undefined} options.firstRowId
+ * @param {bigint} options.sequenceNumber
+ * @param {string} [options.rowIdColumn]
+ * @param {string} [options.lastUpdatedSequenceNumberColumn]
+ */
+function applyRowLineage(out, {
+  row,
+  pos,
+  firstRowId,
+  sequenceNumber,
+  rowIdColumn,
+  lastUpdatedSequenceNumberColumn,
+}) {
+  const storedRowId = rowIdColumn ? row[rowIdColumn] : undefined
+  const storedLastUpdatedSequenceNumber = lastUpdatedSequenceNumberColumn
+    ? row[lastUpdatedSequenceNumberColumn]
+    : undefined
+  if (storedRowId != null) {
+    out._row_id = storedRowId
+  } else if (firstRowId != null) {
+    out._row_id = BigInt(firstRowId) + pos
+  } else {
+    out._row_id = null
+  }
+
+  if (storedLastUpdatedSequenceNumber != null) {
+    out._last_updated_sequence_number = storedLastUpdatedSequenceNumber
+  } else if (firstRowId != null) {
+    out._last_updated_sequence_number = sequenceNumber
+  } else {
+    out._last_updated_sequence_number = null
   }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -48,7 +48,7 @@ export interface TableMetadata {
   refs?: Record<string, SnapshotRef>
   statistics?: TableStatistics[]
   'partition-statistics'?: PartitionStatistics[]
-  'next-row-id'?: bigint // required in V3
+  'next-row-id'?: number | bigint // required in V3
   // 'encryption-keys'?: EncryptionKeys[]
 }
 
@@ -179,7 +179,7 @@ export interface Snapshot {
     'total-equality-deletes': string
   }
   'schema-id'?: number
-  'first-row-id'?: bigint // V3
+  'first-row-id'?: number // V3
   'added-rows'?: number // V3
 }
 
@@ -210,6 +210,7 @@ export interface SnapshotRef {
 export type TableRequirement =
   | { type: 'assert-table-uuid', uuid: string }
   | { type: 'assert-ref-snapshot-id', ref: string, 'snapshot-id': number | null }
+  | { type: 'assert-next-row-id', 'next-row-id': number }
 
 /**
  * Subset of Iceberg REST `TableUpdate`s that the staging API emits.
@@ -259,7 +260,7 @@ export interface Manifest {
   deleted_rows_count: bigint
   partitions?: FieldSummary[]
   // key_metadata?: unknown
-  first_row_id?: bigint
+  first_row_id?: bigint | number
 }
 
 export interface ManifestEntry {
@@ -294,7 +295,7 @@ export interface DataFile {
   split_offsets?: bigint[]
   equality_ids?: number[]
   sort_order_id?: number
-  first_row_id?: bigint
+  first_row_id?: bigint | number
   referenced_data_file?: string
   content_offset?: bigint
   content_size_in_bytes?: bigint

--- a/src/write/commit.js
+++ b/src/write/commit.js
@@ -78,6 +78,11 @@ export function checkRequirements(metadata, requirements) {
       if (current !== req['snapshot-id']) {
         throw new Error(`requirement failed: ref ${req.ref} expected snapshot ${req['snapshot-id']}, got ${current}`)
       }
+    } else if (req.type === 'assert-next-row-id') {
+      const current = Number(metadata['next-row-id'] ?? 0)
+      if (current !== req['next-row-id']) {
+        throw new Error(`requirement failed: next-row-id expected ${req['next-row-id']}, got ${current}`)
+      }
     } else {
       throw new Error(`unknown requirement: ${JSON.stringify(req)}`)
     }
@@ -105,6 +110,10 @@ export function applyUpdates(metadata, updates) {
         snapshots: [...next.snapshots ?? [], snap],
         'last-sequence-number': Math.max(next['last-sequence-number'] ?? 0, snap['sequence-number']),
         'last-updated-ms': snap['timestamp-ms'],
+      }
+      if (next['format-version'] >= 3 && snap['first-row-id'] !== undefined && snap['added-rows'] !== undefined) {
+        const nextRowId = snap['first-row-id'] + snap['added-rows']
+        next['next-row-id'] = Math.max(Number(next['next-row-id'] ?? 0), nextRowId)
       }
     } else if (up.action === 'set-snapshot-ref') {
       /** @type {SnapshotRef} */

--- a/src/write/manifest-list.js
+++ b/src/write/manifest-list.js
@@ -2,19 +2,18 @@ import { avroWrite } from '../avro/avro.write.js'
 
 /**
  * @import {Writer} from 'hyparquet-writer'
- * @import {AvroRecord, Manifest} from '../../src/types.js'
+ * @import {AvroField, AvroRecord, Manifest} from '../../src/types.js'
  */
 
 /**
- * Avro schema for a v2 manifest list entry. Field ids and order match the
- * Iceberg v2 spec.
+ * Build an Avro schema for a manifest list entry.
  *
- * @type {AvroRecord}
+ * @param {2|3} formatVersion
+ * @returns {AvroRecord}
  */
-const manifestFileSchema = {
-  type: 'record',
-  name: 'manifest_file',
-  fields: [
+function manifestFileSchema(formatVersion) {
+  /** @type {AvroField[]} */
+  const fields = [
     { name: 'manifest_path', type: 'string', 'field-id': 500 },
     { name: 'manifest_length', type: 'long', 'field-id': 501 },
     { name: 'partition_spec_id', type: 'int', 'field-id': 502 },
@@ -34,7 +33,16 @@ const manifestFileSchema = {
       default: null,
       'field-id': 507,
     },
-  ],
+  ]
+  if (formatVersion >= 3) {
+    fields.push({ name: 'first_row_id', type: ['null', 'long'], default: null, 'field-id': 520 })
+  }
+
+  return {
+    type: 'record',
+    name: 'manifest_file',
+    fields,
+  }
 }
 
 /**
@@ -45,31 +53,39 @@ const manifestFileSchema = {
  * @param {bigint} options.snapshotId
  * @param {bigint} options.sequenceNumber
  * @param {Manifest[]} options.manifests
+ * @param {2|3} [options.formatVersion]
  */
-export function writeManifestList({ writer, snapshotId, sequenceNumber, manifests }) {
-  const records = manifests.map(m => ({
-    manifest_path: m.manifest_path,
-    manifest_length: m.manifest_length,
-    partition_spec_id: m.partition_spec_id,
-    content: m.content,
-    sequence_number: m.sequence_number ?? sequenceNumber,
-    min_sequence_number: m.min_sequence_number ?? sequenceNumber,
-    added_snapshot_id: m.added_snapshot_id,
-    added_files_count: m.added_files_count,
-    existing_files_count: m.existing_files_count,
-    deleted_files_count: m.deleted_files_count,
-    added_rows_count: m.added_rows_count,
-    existing_rows_count: m.existing_rows_count,
-    deleted_rows_count: m.deleted_rows_count,
-    partitions: [],
-  }))
+export function writeManifestList({ writer, snapshotId, sequenceNumber, manifests, formatVersion = 2 }) {
+  const records = manifests.map(m => {
+    /** @type {Record<string, any>} */
+    const record = {
+      manifest_path: m.manifest_path,
+      manifest_length: m.manifest_length,
+      partition_spec_id: m.partition_spec_id,
+      content: m.content,
+      sequence_number: m.sequence_number ?? sequenceNumber,
+      min_sequence_number: m.min_sequence_number ?? sequenceNumber,
+      added_snapshot_id: m.added_snapshot_id,
+      added_files_count: m.added_files_count,
+      existing_files_count: m.existing_files_count,
+      deleted_files_count: m.deleted_files_count,
+      added_rows_count: m.added_rows_count,
+      existing_rows_count: m.existing_rows_count,
+      deleted_rows_count: m.deleted_rows_count,
+      partitions: [],
+    }
+    if (formatVersion >= 3) {
+      record.first_row_id = m.content === 0 ? m.first_row_id ?? null : null
+    }
+    return record
+  })
 
   avroWrite({
     writer,
-    schema: manifestFileSchema,
+    schema: manifestFileSchema(formatVersion),
     records,
     metadata: {
-      'format-version': '2',
+      'format-version': String(formatVersion),
       'snapshot-id': String(snapshotId),
       'sequence-number': String(sequenceNumber),
     },

--- a/src/write/manifest.js
+++ b/src/write/manifest.js
@@ -2,51 +2,59 @@ import { avroWrite } from '../avro/avro.write.js'
 
 /**
  * @import {Writer} from 'hyparquet-writer'
- * @import {AvroRecord, DataFile, Schema} from '../../src/types.js'
+ * @import {AvroField, AvroRecord, DataFile, Schema} from '../../src/types.js'
  */
 
 /**
- * Avro schema for a v2 manifest entry with an unpartitioned data file.
- * Field order and ids match the Iceberg v2 spec so other readers can parse it.
+ * Build an Avro schema for an unpartitioned data manifest entry.
  *
- * @type {AvroRecord}
+ * @param {2|3} formatVersion
+ * @returns {AvroRecord}
  */
-const manifestEntrySchema = {
-  type: 'record',
-  name: 'manifest_entry',
-  fields: [
-    { name: 'status', type: 'int', 'field-id': 0 },
-    { name: 'snapshot_id', type: ['null', 'long'], default: null, 'field-id': 1 },
-    { name: 'sequence_number', type: ['null', 'long'], default: null, 'field-id': 3 },
-    { name: 'file_sequence_number', type: ['null', 'long'], default: null, 'field-id': 4 },
+function manifestEntrySchema(formatVersion) {
+  /** @type {AvroField[]} */
+  const dataFileFields = [
+    { name: 'content', type: 'int', 'field-id': 134 },
+    { name: 'file_path', type: 'string', 'field-id': 100 },
+    { name: 'file_format', type: 'string', 'field-id': 101 },
     {
-      name: 'data_file',
-      'field-id': 2,
-      type: {
-        type: 'record',
-        name: 'r2',
-        fields: [
-          { name: 'content', type: 'int', 'field-id': 134 },
-          { name: 'file_path', type: 'string', 'field-id': 100 },
-          { name: 'file_format', type: 'string', 'field-id': 101 },
-          {
-            name: 'partition',
-            'field-id': 102,
-            type: { type: 'record', name: 'r102', fields: [] },
-          },
-          { name: 'record_count', type: 'long', 'field-id': 103 },
-          { name: 'file_size_in_bytes', type: 'long', 'field-id': 104 },
-          mapField('column_sizes', 108, 'k117_v118', 117, 118, 'long'),
-          mapField('value_counts', 109, 'k119_v120', 119, 120, 'long'),
-          mapField('null_value_counts', 110, 'k121_v122', 121, 122, 'long'),
-          mapField('nan_value_counts', 137, 'k138_v139', 138, 139, 'long'),
-          mapField('lower_bounds', 125, 'k126_v127', 126, 127, 'bytes'),
-          mapField('upper_bounds', 128, 'k129_v130', 129, 130, 'bytes'),
-          { name: 'sort_order_id', type: ['null', 'int'], default: null, 'field-id': 140 },
-        ],
-      },
+      name: 'partition',
+      'field-id': 102,
+      type: { type: 'record', name: 'r102', fields: [] },
     },
-  ],
+    { name: 'record_count', type: 'long', 'field-id': 103 },
+    { name: 'file_size_in_bytes', type: 'long', 'field-id': 104 },
+    mapField('column_sizes', 108, 'k117_v118', 117, 118, 'long'),
+    mapField('value_counts', 109, 'k119_v120', 119, 120, 'long'),
+    mapField('null_value_counts', 110, 'k121_v122', 121, 122, 'long'),
+    mapField('nan_value_counts', 137, 'k138_v139', 138, 139, 'long'),
+    mapField('lower_bounds', 125, 'k126_v127', 126, 127, 'bytes'),
+    mapField('upper_bounds', 128, 'k129_v130', 129, 130, 'bytes'),
+    { name: 'sort_order_id', type: ['null', 'int'], default: null, 'field-id': 140 },
+  ]
+  if (formatVersion >= 3) {
+    dataFileFields.push({ name: 'first_row_id', type: ['null', 'long'], default: null, 'field-id': 142 })
+  }
+
+  return {
+    type: 'record',
+    name: 'manifest_entry',
+    fields: [
+      { name: 'status', type: 'int', 'field-id': 0 },
+      { name: 'snapshot_id', type: ['null', 'long'], default: null, 'field-id': 1 },
+      { name: 'sequence_number', type: ['null', 'long'], default: null, 'field-id': 3 },
+      { name: 'file_sequence_number', type: ['null', 'long'], default: null, 'field-id': 4 },
+      {
+        name: 'data_file',
+        'field-id': 2,
+        type: {
+          type: 'record',
+          name: 'r2',
+          fields: dataFileFields,
+        },
+      },
+    ],
+  }
 }
 
 /**
@@ -59,7 +67,7 @@ const manifestEntrySchema = {
  * @param {number} keyId
  * @param {number} valueId
  * @param {'long'|'bytes'} valueType
- * @returns {import('../../src/types.js').AvroField}
+ * @returns {AvroField}
  */
 function mapField(name, fieldId, recName, keyId, valueId, valueType) {
   return {
@@ -115,36 +123,43 @@ function encodeMap(m) {
  * @param {Schema} options.schema - current table schema (embedded in metadata)
  * @param {bigint} options.snapshotId
  * @param {DataFile} options.dataFile
+ * @param {2|3} [options.formatVersion]
  */
-export function writeDataManifest({ writer, schema, snapshotId, dataFile }) {
+export function writeDataManifest({ writer, schema, snapshotId, dataFile, formatVersion = 2 }) {
+  /** @type {Record<string, any>} */
+  const dataFileRecord = {
+    content: dataFile.content,
+    file_path: dataFile.file_path,
+    file_format: dataFile.file_format.toUpperCase(),
+    partition: {},
+    record_count: dataFile.record_count,
+    file_size_in_bytes: dataFile.file_size_in_bytes,
+    column_sizes: encodeMap(dataFile.column_sizes),
+    value_counts: encodeMap(dataFile.value_counts),
+    null_value_counts: encodeMap(dataFile.null_value_counts),
+    nan_value_counts: encodeMap(dataFile.nan_value_counts),
+    lower_bounds: encodeMap(dataFile.lower_bounds),
+    upper_bounds: encodeMap(dataFile.upper_bounds),
+    sort_order_id: dataFile.sort_order_id ?? 0,
+  }
+  if (formatVersion >= 3) {
+    dataFileRecord.first_row_id = dataFile.first_row_id ?? null
+  }
+
   const record = {
     status: 1,
     snapshot_id: snapshotId,
     sequence_number: null,
     file_sequence_number: null,
-    data_file: {
-      content: dataFile.content,
-      file_path: dataFile.file_path,
-      file_format: dataFile.file_format.toUpperCase(),
-      partition: {},
-      record_count: dataFile.record_count,
-      file_size_in_bytes: dataFile.file_size_in_bytes,
-      column_sizes: encodeMap(dataFile.column_sizes),
-      value_counts: encodeMap(dataFile.value_counts),
-      null_value_counts: encodeMap(dataFile.null_value_counts),
-      nan_value_counts: encodeMap(dataFile.nan_value_counts),
-      lower_bounds: encodeMap(dataFile.lower_bounds),
-      upper_bounds: encodeMap(dataFile.upper_bounds),
-      sort_order_id: dataFile.sort_order_id ?? 0,
-    },
+    data_file: dataFileRecord,
   }
 
   avroWrite({
     writer,
-    schema: manifestEntrySchema,
+    schema: manifestEntrySchema(formatVersion),
     records: [record],
     metadata: {
-      'format-version': '2',
+      'format-version': String(formatVersion),
       content: 'data',
       schema: icebergSchemaJson(schema),
       'partition-spec': '[]',

--- a/src/write/stage.js
+++ b/src/write/stage.js
@@ -6,7 +6,7 @@ import { writeManifestList } from './manifest-list.js'
 import { computeColumnStats } from './stats.js'
 
 /**
- * @import {Manifest, Resolver, Snapshot, StagedUpdate, TableMetadata} from '../../src/types.js'
+ * @import {Manifest, Resolver, Snapshot, StagedUpdate, TableMetadata, TableRequirement} from '../../src/types.js'
  */
 
 /**
@@ -17,7 +17,7 @@ import { computeColumnStats } from './stats.js'
  * No metadata.json or version-hint is written — pass the result to a commit
  * function (`fileCatalogCommit`, or a future `restCatalogCommitTable`).
  *
- * Only supports v2 tables with a flat unpartitioned schema and primitive
+ * Only supports v2/v3 tables with a flat unpartitioned schema and primitive
  * column types.
  *
  * @param {object} options
@@ -30,9 +30,11 @@ import { computeColumnStats } from './stats.js'
 export async function icebergStageAppend({ tableUrl, metadata, records, resolver }) {
   if (!tableUrl) throw new Error('tableUrl is required')
   if (!resolver?.writer) throw new Error('resolver.writer is required')
-  if (metadata['format-version'] !== 2) {
+  if (metadata['format-version'] !== 2 && metadata['format-version'] !== 3) {
     throw new Error(`unsupported format-version: ${metadata['format-version']}`)
   }
+  const formatVersion = /** @type {2|3} */ (metadata['format-version'])
+  const rowLineage = formatVersion >= 3
   const partitionSpec = metadata['partition-specs'].find(s => s['spec-id'] === metadata['default-spec-id'])
   if (!partitionSpec || partitionSpec.fields.length) {
     throw new Error('icebergStageAppend only supports unpartitioned tables')
@@ -45,6 +47,7 @@ export async function icebergStageAppend({ tableUrl, metadata, records, resolver
   const dataUuid = uuid4()
   const manifestUuid = uuid4()
   const timestampMs = Date.now()
+  const firstRowId = rowLineage ? BigInt(metadata['next-row-id'] ?? 0) : undefined
 
   // 1. Write parquet data file
   const dataPath = `${tableUrl}/data/${dataUuid}.parquet`
@@ -74,6 +77,7 @@ export async function icebergStageAppend({ tableUrl, metadata, records, resolver
       upper_bounds: stats.upper_bounds,
       sort_order_id: 0,
     },
+    formatVersion,
   })
   const manifestLength = BigInt(manifestWriter.offset)
 
@@ -97,9 +101,10 @@ export async function icebergStageAppend({ tableUrl, metadata, records, resolver
   // 3. Carry forward manifests from prior snapshot, then write new manifest list
   const priorManifests = await loadPriorManifests(metadata, resolver)
   const allManifests = [newManifest, ...priorManifests]
+  const addedRows = rowLineage ? assignFirstRowIds(allManifests, firstRowId ?? 0n) : 0n
   const manifestListPath = `${tableUrl}/metadata/snap-${snapshotId}-1-${manifestUuid}.avro`
   const listWriter = resolver.writer(translateS3Url(manifestListPath))
-  writeManifestList({ writer: listWriter, snapshotId, sequenceNumber, manifests: allManifests })
+  writeManifestList({ writer: listWriter, snapshotId, sequenceNumber, manifests: allManifests, formatVersion })
 
   // 4. Build the new snapshot
   const prevSummary = currentSnapshot(metadata)?.summary
@@ -129,19 +134,31 @@ export async function icebergStageAppend({ tableUrl, metadata, records, resolver
     },
     'schema-id': metadata['current-schema-id'],
   }
+  if (rowLineage) {
+    snapshot['first-row-id'] = toMetadataLong(firstRowId ?? 0n)
+    snapshot['added-rows'] = toMetadataLong(addedRows)
+  }
   const parentId = metadata['current-snapshot-id']
   if (parentId !== undefined) snapshot['parent-snapshot-id'] = parentId
+  /** @type {TableRequirement[]} */
+  const requirements = [
+    { type: 'assert-table-uuid', uuid: metadata['table-uuid'] },
+    {
+      type: 'assert-ref-snapshot-id',
+      ref: 'main',
+      'snapshot-id': metadata['current-snapshot-id'] ?? null,
+    },
+  ]
+  if (rowLineage) {
+    requirements.push({
+      type: 'assert-next-row-id',
+      'next-row-id': toMetadataLong(metadata['next-row-id'] ?? 0),
+    })
+  }
 
   return {
     snapshot,
-    requirements: [
-      { type: 'assert-table-uuid', uuid: metadata['table-uuid'] },
-      {
-        type: 'assert-ref-snapshot-id',
-        ref: 'main',
-        'snapshot-id': metadata['current-snapshot-id'] ?? null,
-      },
-    ],
+    requirements,
     updates: [
       { action: 'add-snapshot', snapshot },
       {
@@ -174,6 +191,48 @@ async function loadPriorManifests(metadata, resolver) {
   const snap = currentSnapshot(metadata)
   if (!snap?.['manifest-list']) return []
   return /** @type {Manifest[]} */ (await fetchAvroRecords(snap['manifest-list'], resolver))
+}
+
+/**
+ * Assign v3 first_row_id values to data manifests that do not already have
+ * them and return the number of newly assigned row IDs.
+ *
+ * @param {Manifest[]} manifests
+ * @param {bigint} firstRowId
+ * @returns {bigint}
+ */
+function assignFirstRowIds(manifests, firstRowId) {
+  let nextFirstRowId = firstRowId
+  let assignedRows = 0n
+  for (const manifest of manifests) {
+    if (manifest.content !== 0) {
+      manifest.first_row_id = undefined
+      continue
+    }
+
+    const rowIdRange = BigInt(manifest.added_rows_count ?? 0) + BigInt(manifest.existing_rows_count ?? 0)
+    if (manifest.first_row_id == null) {
+      manifest.first_row_id = nextFirstRowId
+      nextFirstRowId += rowIdRange
+      assignedRows += rowIdRange
+    } else {
+      const manifestEnd = BigInt(manifest.first_row_id) + rowIdRange
+      if (manifestEnd > nextFirstRowId) nextFirstRowId = manifestEnd
+    }
+  }
+  return assignedRows
+}
+
+/**
+ * @param {number|bigint} value
+ * @returns {number}
+ */
+function toMetadataLong(value) {
+  const out = Number(value)
+  if (!Number.isSafeInteger(out)) {
+    throw new Error(`metadata long exceeds JavaScript safe integer range: ${value}`)
+  }
+  return out
 }
 
 /**

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -3,6 +3,10 @@ import { icebergCreate } from '../src/create.js'
 import * as fetchModule from '../src/fetch.js'
 import { ByteWriter } from 'hyparquet-writer'
 
+/**
+ * @import {Schema} from '../src/types.js'
+ */
+
 describe('createIceberg', () => {
   const tableUrl = 's3://test-bucket/table-path'
   const translatedTableUrl = 'https://test-bucket.s3.amazonaws.com/table-path'
@@ -64,7 +68,7 @@ describe('createIceberg', () => {
       return writers[path]
     })
     const resolver = { reader: vi.fn(), writer }
-    /** @type {import('../src/types.js').Schema} */
+    /** @type {Schema} */
     const schema = {
       type: 'struct',
       'schema-id': 0,

--- a/test/write/manifest-list.test.js
+++ b/test/write/manifest-list.test.js
@@ -57,4 +57,40 @@ describe('writeManifestList', () => {
       deleted_rows_count: 0n,
     })
   })
+
+  it('writes v3 first_row_id metadata', async () => {
+    /** @type {Manifest} */
+    const manifest = {
+      manifest_path: 's3://bucket/table/metadata/m0.avro',
+      manifest_length: 1234n,
+      partition_spec_id: 0,
+      content: 0,
+      added_snapshot_id: 999n,
+      added_files_count: 1,
+      existing_files_count: 0,
+      deleted_files_count: 0,
+      added_rows_count: 3n,
+      existing_rows_count: 0n,
+      deleted_rows_count: 0n,
+      first_row_id: 100n,
+    }
+    const writer = new ByteWriter()
+    writeManifestList({
+      writer,
+      snapshotId: 999n,
+      sequenceNumber: 1n,
+      manifests: [manifest],
+      formatVersion: 3,
+    })
+    const buffer = writer.getBuffer()
+
+    const reader = { view: new DataView(buffer), offset: 0 }
+    const { metadata, syncMarker } = await avroMetadata(reader)
+    expect(metadata['format-version']).toBe('3')
+
+    const records = await avroRead({ reader, metadata, syncMarker })
+    expect(records[0]).toMatchObject({
+      first_row_id: 100n,
+    })
+  })
 })

--- a/test/write/manifest.test.js
+++ b/test/write/manifest.test.js
@@ -82,4 +82,17 @@ describe('writeDataManifest', () => {
     expect(df.nan_value_counts).toBeUndefined()
     expect(df.column_sizes).toBeUndefined()
   })
+
+  it('writes v3 first_row_id as null for new data files', async () => {
+    const writer = new ByteWriter()
+    writeDataManifest({ writer, schema, snapshotId: 12345n, dataFile, formatVersion: 3 })
+    const buffer = writer.getBuffer()
+
+    const reader = { view: new DataView(buffer), offset: 0 }
+    const { metadata, syncMarker } = await avroMetadata(reader)
+    expect(metadata['format-version']).toBe('3')
+
+    const records = await avroRead({ reader, metadata, syncMarker })
+    expect(records[0].data_file.first_row_id).toBeUndefined()
+  })
 })

--- a/test/write/stage.test.js
+++ b/test/write/stage.test.js
@@ -108,6 +108,40 @@ describe('icebergStageAppend', () => {
     expect(read).toEqual(records)
   })
 
+  it('assigns row lineage for v3 appends', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+    const tableUrl = 'http://test/stage-v3'
+    const { resolver } = memResolver()
+
+    const created = await icebergCreate({ tableUrl, resolver, schema })
+    const v3Metadata = { ...created, 'format-version': 3, 'next-row-id': 100 }
+    const records = [{ id: 1n, name: 'alice' }, { id: 2n, name: 'bob' }]
+
+    const staged = await icebergStageAppend({ tableUrl, metadata: v3Metadata, records, resolver })
+    expect(staged.requirements).toContainEqual({ type: 'assert-next-row-id', 'next-row-id': 100 })
+    expect(staged.snapshot['first-row-id']).toBe(100)
+    expect(staged.snapshot['added-rows']).toBe(2)
+
+    const committed = await fileCatalogCommit({ tableUrl, metadata: v3Metadata, staged, resolver })
+    expect(committed['next-row-id']).toBe(102)
+
+    const read = await icebergRead({ tableUrl, metadata: committed, resolver })
+    expect(read).toEqual([
+      {
+        id: 1n,
+        name: 'alice',
+        _row_id: 100n,
+        _last_updated_sequence_number: 1n,
+      },
+      {
+        id: 2n,
+        name: 'bob',
+        _row_id: 101n,
+        _last_updated_sequence_number: 1n,
+      },
+    ])
+  })
+
   it('carries forward prior manifests across two sequential commits', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
     const tableUrl = 'http://test/stage3'


### PR DESCRIPTION
- Adds Iceberg v3 row lineage support for the existing append/read path.
- Writes v3 manifest/list row lineage fields: data file `first_row_id` and manifest list `first_row_id`.
- Assigns v3 snapshot `first-row-id` / `added-rows` during staged appends and advances table `next-row-id` on commit.
- Adds `assert-next-row-id` commit requirement to protect row lineage allocation from stale commits.
- Applies read-time row lineage inheritance, synthesizing `_row_id` and `_last_updated_sequence_number` when data files omit them.
- Adds focused tests for v3 manifest metadata, staged append lineage, commit `next-row-id`, and read output lineage fields.
