### PR TITLE
Add Puffin file reader and Deletion Vector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,19 +143,19 @@ Icebird aims to support reading any Iceberg table, but currently only supports a
 | ------- | --------- | ----- |
 | Read Iceberg v1 Tables | ✅ | |
 | Read Iceberg v2 Tables | ✅ | |
-| Read Iceberg v3 Tables | ❌ | Needs deletion vectors / Puffin support and stricter delete planning. |
+| Read Iceberg v3 Tables | ❌ | Needs stricter delete planning before broad v3 support. |
 | Parquet Storage | ✅ | |
 | Avro Storage | ✅ | |
 | ORC Storage | ❌ | |
-| Puffin Storage | ❌ | Needed for v3 deletion vectors. |
+| Puffin Storage | ⚠️ | Supports uncompressed `deletion-vector-v1` blobs only. |
 | File-based Catalog (version-hint.text) | ✅ | |
 | REST Catalog | ✅ | |
 | Hive Catalog | ❌ | |
 | Glue Catalog | ❌ | |
 | Service-based Catalog | ❌ | |
-| Position Deletes | ✅ | Parquet position delete files only; v3 deletion vectors are not supported. |
-| Equality Deletes | ⚠️ | Needs `equality_ids`, null-match semantics, and partition scope handling. |
-| Binary Deletion Vectors | ❌ | Required before broad v3 table support. |
+| Position Deletes | ✅ | Supports Parquet position delete files and Puffin deletion vectors. |
+| Equality Deletes | ⚠️ | Needs delete partition scope handling. |
+| Binary Deletion Vectors | ✅ | Supports uncompressed Puffin `deletion-vector-v1` blobs. |
 | Delete Partition Scope | ❌ | Needed for correct delete application on partitioned tables. |
 | Rename Columns | ✅ | |
 | Efficient Partitioned Read Queries | ❌ | |

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,6 +2,7 @@ import { asyncBufferFromUrl, cachedAsyncBuffer, parquetMetadataAsync, parquetRea
 import { compressors } from 'hyparquet-compressors'
 import { avroRead } from './avro/avro.read.js'
 import { avroMetadata } from './avro/avro.metadata.js'
+import { puffinReadDeletionVector } from './puffin/puffin.js'
 import { sanitize } from './utils.js'
 
 /**
@@ -114,18 +115,38 @@ export async function fetchDeleteMaps(deleteEntries, resolver) {
     const file = cachedAsyncBuffer(asyncBuffer)
 
     if (content === 1) { // position delete
-      const deleteRows = await parquetReadObjects({ file, compressors })
-      for (const deleteRow of deleteRows) {
-        const { file_path, pos } = deleteRow
-        if (!file_path) throw new Error('position delete missing target file path')
-        if (pos === undefined) throw new Error('position delete missing pos')
-        // note: pos is relative to the data file's row order
-        let set = positionDeletesMap.get(file_path)
+      if (isDeletionVector(deleteEntry)) {
+        const { referenced_data_file, content_offset, content_size_in_bytes } = deleteEntry.data_file
+        if (!referenced_data_file) throw new Error('deletion vector missing referenced_data_file')
+        if (content_offset == null) throw new Error('deletion vector missing content_offset')
+        if (content_size_in_bytes == null) throw new Error('deletion vector missing content_size_in_bytes')
+        const positions = await puffinReadDeletionVector(file, {
+          offset: content_offset,
+          length: content_size_in_bytes,
+          referencedDataFile: referenced_data_file,
+        })
+        let set = positionDeletesMap.get(referenced_data_file)
         if (!set) {
           set = new Set()
-          positionDeletesMap.set(file_path, set)
+          positionDeletesMap.set(referenced_data_file, set)
         }
-        set.add(pos)
+        for (const pos of positions) {
+          set.add(pos)
+        }
+      } else {
+        const deleteRows = await parquetReadObjects({ file, compressors })
+        for (const deleteRow of deleteRows) {
+          const { file_path, pos } = deleteRow
+          if (!file_path) throw new Error('position delete missing target file path')
+          if (pos === undefined) throw new Error('position delete missing pos')
+          // note: pos is relative to the data file's row order
+          let set = positionDeletesMap.get(file_path)
+          if (!set) {
+            set = new Set()
+            positionDeletesMap.set(file_path, set)
+          }
+          set.add(pos)
+        }
       }
     } else if (content === 2) { // equality delete
       const { sequence_number } = deleteEntry
@@ -153,6 +174,17 @@ export async function fetchDeleteMaps(deleteEntries, resolver) {
   }))
 
   return { positionDeletesMap, equalityDeletesMap }
+}
+
+/**
+ * @param {ManifestEntry} deleteEntry
+ * @returns {boolean}
+ */
+function isDeletionVector(deleteEntry) {
+  const dataFile = deleteEntry.data_file
+  return dataFile.file_format.toLowerCase() === 'puffin' ||
+    dataFile.content_offset != null ||
+    dataFile.content_size_in_bytes != null
 }
 
 /**

--- a/src/puffin/deletion-vector.js
+++ b/src/puffin/deletion-vector.js
@@ -117,7 +117,7 @@ function roaringBitmap32Length(bytes) {
  */
 function isRunContainer(runContainers, index) {
   if (!runContainers) return false
-  return Boolean(runContainers[Math.floor(index / 8)] & (1 << (index % 8)))
+  return Boolean(runContainers[Math.floor(index / 8)] & 1 << index % 8)
 }
 
 let crcTable
@@ -130,9 +130,9 @@ function crc32(bytes) {
   crcTable ??= makeCrcTable()
   let crc = 0xffffffff
   for (const byte of bytes) {
-    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+    crc = crcTable[(crc ^ byte) & 0xff] ^ crc >>> 8
   }
-  return (crc ^ 0xffffffff) >>> 0
+  return ~crc >>> 0
 }
 
 /**
@@ -143,7 +143,7 @@ function makeCrcTable() {
   for (let i = 0; i < table.length; i++) {
     let c = i
     for (let j = 0; j < 8; j++) {
-      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+      c = c & 1 ? 0xedb88320 ^ c >>> 1 : c >>> 1
     }
     table[i] = c >>> 0
   }

--- a/src/puffin/deletion-vector.js
+++ b/src/puffin/deletion-vector.js
@@ -1,0 +1,151 @@
+import { readRoaringBitmap32 } from './roaring.js'
+
+const DV_MAGIC = 0xd1d33964
+
+/**
+ * Decode a Puffin `deletion-vector-v1` blob into deleted row positions.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {Set<bigint>}
+ */
+export function readDeletionVector(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const payloadLength = view.getUint32(0, false)
+  if (payloadLength !== bytes.byteLength - 8) {
+    throw new Error(`invalid deletion vector length: ${payloadLength}`)
+  }
+  if (view.getUint32(4, false) !== DV_MAGIC) {
+    throw new Error('invalid deletion vector magic')
+  }
+
+  const expectedCrc = view.getUint32(bytes.byteLength - 4, false)
+  const payload = bytes.subarray(4, bytes.byteLength - 4)
+  const actualCrc = crc32(payload)
+  if (actualCrc !== expectedCrc) {
+    throw new Error('deletion vector crc mismatch')
+  }
+
+  const vector = bytes.subarray(8, bytes.byteLength - 4)
+  return readPositionVector(vector)
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {Set<bigint>}
+ */
+function readPositionVector(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  let offset = 0
+  const bitmapCount = view.getBigUint64(offset, true)
+  offset += 8
+  if (bitmapCount > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(`too many deletion vector bitmaps: ${bitmapCount}`)
+  }
+
+  /** @type {Set<bigint>} */
+  const positions = new Set()
+  for (let i = 0; i < Number(bitmapCount); i++) {
+    const key = view.getUint32(offset, true)
+    offset += 4
+    const start = offset
+    const values = readRoaringBitmap32(bytes.subarray(start))
+    offset = start + roaringBitmap32Length(bytes.subarray(start))
+    const keyBase = BigInt(key) << 32n
+    for (const value of values) {
+      positions.add(keyBase + BigInt(value))
+    }
+  }
+  return positions
+}
+
+/**
+ * Return the number of bytes used by one serialized 32-bit Roaring bitmap.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {number}
+ */
+function roaringBitmap32Length(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  let offset = 0
+  const cookie = view.getUint32(offset, true)
+  offset += 4
+  let size
+  let runContainers
+  if (cookie === 12346) {
+    size = view.getUint32(offset, true)
+    offset += 4
+  } else if ((cookie & 0xffff) === 12347) {
+    size = (cookie >>> 16) + 1
+    const runBytes = Math.ceil(size / 8)
+    runContainers = bytes.subarray(offset, offset + runBytes)
+    offset += runBytes
+  } else {
+    throw new Error(`invalid roaring cookie: ${cookie}`)
+  }
+
+  const cardinalities = new Array(size)
+  const types = new Array(size)
+  for (let i = 0; i < size; i++) {
+    offset += 2
+    cardinalities[i] = view.getUint16(offset, true) + 1
+    offset += 2
+    types[i] = isRunContainer(runContainers, i)
+      ? 'run'
+      : cardinalities[i] <= 4096 ? 'array' : 'bitmap'
+  }
+  if (cookie === 12346 || size >= 4) {
+    offset += 4 * size
+  }
+
+  for (let i = 0; i < size; i++) {
+    if (types[i] === 'array') {
+      offset += cardinalities[i] * 2
+    } else if (types[i] === 'bitmap') {
+      offset += 8192
+    } else {
+      const runCount = view.getUint16(offset, true)
+      offset += 2 + runCount * 4
+    }
+  }
+  return offset
+}
+
+/**
+ * @param {Uint8Array | undefined} runContainers
+ * @param {number} index
+ * @returns {boolean}
+ */
+function isRunContainer(runContainers, index) {
+  if (!runContainers) return false
+  return Boolean(runContainers[Math.floor(index / 8)] & (1 << (index % 8)))
+}
+
+let crcTable
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {number}
+ */
+function crc32(bytes) {
+  crcTable ??= makeCrcTable()
+  let crc = 0xffffffff
+  for (const byte of bytes) {
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+/**
+ * @returns {Uint32Array}
+ */
+function makeCrcTable() {
+  const table = new Uint32Array(256)
+  for (let i = 0; i < table.length; i++) {
+    let c = i
+    for (let j = 0; j < 8; j++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    }
+    table[i] = c >>> 0
+  }
+  return table
+}

--- a/src/puffin/puffin.js
+++ b/src/puffin/puffin.js
@@ -1,0 +1,90 @@
+import { readDeletionVector } from './deletion-vector.js'
+
+const PUFFIN_MAGIC = 0x50464131
+
+/**
+ * Read a Puffin `deletion-vector-v1` blob selected by manifest offset/length.
+ *
+ * @import {AsyncBuffer} from 'hyparquet'
+ * @param {AsyncBuffer} file
+ * @param {object} options
+ * @param {number|bigint} options.offset
+ * @param {number|bigint} options.length
+ * @param {string} [options.referencedDataFile]
+ * @returns {Promise<Set<bigint>>}
+ */
+export async function puffinReadDeletionVector(file, { offset, length, referencedDataFile }) {
+  const buffer = await file.slice(0, file.byteLength)
+  const bytes = new Uint8Array(buffer)
+  const metadata = readPuffinMetadata(bytes)
+  const blob = metadata.blobs.find(blob => {
+    return blob.type === 'deletion-vector-v1' &&
+      BigInt(blob.offset) === BigInt(offset) &&
+      BigInt(blob.length) === BigInt(length)
+  })
+  if (!blob) throw new Error('puffin deletion-vector-v1 blob not found')
+  if (blob['compression-codec']) {
+    throw new Error(`unsupported puffin blob compression: ${blob['compression-codec']}`)
+  }
+  if (referencedDataFile && blob.properties?.['referenced-data-file'] !== referencedDataFile) {
+    throw new Error('puffin deletion vector referenced-data-file mismatch')
+  }
+  const start = toSafeNumber(blob.offset)
+  const end = start + toSafeNumber(blob.length)
+  return readDeletionVector(bytes.subarray(start, end))
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {PuffinFileMetadata}
+ */
+export function readPuffinMetadata(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  if (view.getUint32(0, false) !== PUFFIN_MAGIC) throw new Error('invalid puffin file magic')
+  if (view.getUint32(bytes.byteLength - 4, false) !== PUFFIN_MAGIC) {
+    throw new Error('invalid puffin footer magic')
+  }
+
+  const payloadSize = view.getInt32(bytes.byteLength - 12, true)
+  if (payloadSize < 0) throw new Error(`invalid puffin footer payload size: ${payloadSize}`)
+  const flags = view.getUint32(bytes.byteLength - 8, true)
+  const compressed = Boolean(flags & 1)
+  if (flags & ~1) throw new Error(`unsupported puffin footer flags: ${flags}`)
+  if (compressed) throw new Error('compressed puffin footers are not supported')
+
+  const payloadStart = bytes.byteLength - 12 - payloadSize
+  const footerMagicStart = payloadStart - 4
+  if (footerMagicStart < 4 || view.getUint32(footerMagicStart, false) !== PUFFIN_MAGIC) {
+    throw new Error('invalid puffin footer start magic')
+  }
+  const payload = bytes.subarray(payloadStart, payloadStart + payloadSize)
+  return JSON.parse(new TextDecoder().decode(payload))
+}
+
+/**
+ * @param {number|bigint} value
+ * @returns {number}
+ */
+function toSafeNumber(value) {
+  const out = Number(value)
+  if (!Number.isSafeInteger(out)) throw new Error(`puffin offset exceeds safe integer range: ${value}`)
+  return out
+}
+
+/**
+ * @typedef {object} PuffinFileMetadata
+ * @property {PuffinBlobMetadata[]} blobs
+ * @property {Record<string, string>} [properties]
+ */
+
+/**
+ * @typedef {object} PuffinBlobMetadata
+ * @property {string} type
+ * @property {number[]} fields
+ * @property {number} snapshot-id
+ * @property {number} sequence-number
+ * @property {number} offset
+ * @property {number} length
+ * @property {string} [compression-codec]
+ * @property {Record<string, string>} [properties]
+ */

--- a/src/puffin/roaring.js
+++ b/src/puffin/roaring.js
@@ -1,0 +1,104 @@
+/**
+ * Decode the Roaring portable bitmap format used inside Iceberg Puffin
+ * `deletion-vector-v1` blobs.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {number[]} sorted 32-bit unsigned values
+ */
+export function readRoaringBitmap32(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  let offset = 0
+  const cookie = view.getUint32(offset, true)
+  offset += 4
+
+  /** @type {number} */
+  let size
+  /** @type {Uint8Array | undefined} */
+  let runContainers
+  if (cookie === 12346) {
+    size = view.getUint32(offset, true)
+    offset += 4
+  } else if ((cookie & 0xffff) === 12347) {
+    size = (cookie >>> 16) + 1
+    const runBytes = Math.ceil(size / 8)
+    runContainers = bytes.subarray(offset, offset + runBytes)
+    offset += runBytes
+  } else {
+    throw new Error(`invalid roaring cookie: ${cookie}`)
+  }
+
+  const keys = new Array(size)
+  const cardinalities = new Array(size)
+  const types = new Array(size)
+  for (let i = 0; i < size; i++) {
+    keys[i] = view.getUint16(offset, true)
+    cardinalities[i] = view.getUint16(offset + 2, true) + 1
+    offset += 4
+    types[i] = isRunContainer(runContainers, i)
+      ? 'run'
+      : cardinalities[i] <= 4096 ? 'array' : 'bitmap'
+  }
+
+  if (cookie === 12346 || size >= 4) {
+    offset += 4 * size
+  }
+
+  /** @type {number[]} */
+  const values = []
+  for (let i = 0; i < size; i++) {
+    const keyBase = keys[i] * 65536
+    const cardinality = cardinalities[i]
+    const type = types[i]
+    if (type === 'array') {
+      for (let j = 0; j < cardinality; j++) {
+        values.push(keyBase + view.getUint16(offset, true))
+        offset += 2
+      }
+    } else if (type === 'bitmap') {
+      for (let word = 0; word < 1024; word++) {
+        let bits = view.getBigUint64(offset, true)
+        offset += 8
+        while (bits) {
+          const bit = trailingZeroes64(bits)
+          values.push(keyBase + word * 64 + bit)
+          bits &= bits - 1n
+        }
+      }
+    } else {
+      const runCount = view.getUint16(offset, true)
+      offset += 2
+      for (let run = 0; run < runCount; run++) {
+        const start = view.getUint16(offset, true)
+        const length = view.getUint16(offset + 2, true) + 1
+        offset += 4
+        for (let value = start; value < start + length; value++) {
+          values.push(keyBase + value)
+        }
+      }
+    }
+  }
+  return values
+}
+
+/**
+ * @param {Uint8Array | undefined} runContainers
+ * @param {number} index
+ * @returns {boolean}
+ */
+function isRunContainer(runContainers, index) {
+  if (!runContainers) return false
+  return Boolean(runContainers[Math.floor(index / 8)] & (1 << (index % 8)))
+}
+
+/**
+ * @param {bigint} value
+ * @returns {number}
+ */
+function trailingZeroes64(value) {
+  let count = 0
+  while ((value & 1n) === 0n) {
+    value >>= 1n
+    count++
+  }
+  return count
+}

--- a/src/puffin/roaring.js
+++ b/src/puffin/roaring.js
@@ -87,7 +87,7 @@ export function readRoaringBitmap32(bytes) {
  */
 function isRunContainer(runContainers, index) {
   if (!runContainers) return false
-  return Boolean(runContainers[Math.floor(index / 8)] & (1 << (index % 8)))
+  return Boolean(runContainers[Math.floor(index / 8)] & 1 << index % 8)
 }
 
 /**

--- a/test/puffin.test.js
+++ b/test/puffin.test.js
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest'
+import { fetchDeleteMaps } from '../src/fetch.js'
+import { readDeletionVector } from '../src/puffin/deletion-vector.js'
+import { puffinReadDeletionVector, readPuffinMetadata } from '../src/puffin/puffin.js'
+import { readRoaringBitmap32 } from '../src/puffin/roaring.js'
+
+describe('puffin deletion vectors', () => {
+  it('decodes roaring array, bitmap, and run containers', () => {
+    expect(readRoaringBitmap32(roaringArray([1, 5, 65535]))).toEqual([1, 5, 65535])
+
+    const bitmapValues = Array.from({ length: 4097 }, (_, i) => i * 2)
+    expect(readRoaringBitmap32(roaringBitmap(bitmapValues))).toEqual(bitmapValues)
+
+    expect(readRoaringBitmap32(roaringRun([[10, 3], [20, 1]]))).toEqual([10, 11, 12, 20])
+  })
+
+  it('decodes deletion-vector-v1 blobs', () => {
+    const blob = deletionVector([1n, 5n, 4294967301n])
+
+    expect(readDeletionVector(blob)).toEqual(new Set([1n, 5n, 4294967301n]))
+  })
+
+  it('reads deletion-vector-v1 blobs from puffin files by offset and length', async () => {
+    const referencedDataFile = 's3://bucket/table/data/a.parquet'
+    const blob = deletionVector([1n, 3n, 9n])
+    const file = puffinFile(blob, referencedDataFile)
+    const metadata = readPuffinMetadata(file)
+    const [blobMetadata] = metadata.blobs
+
+    const deletes = await puffinReadDeletionVector(asyncBuffer(file), {
+      offset: blobMetadata.offset,
+      length: blobMetadata.length,
+      referencedDataFile,
+    })
+
+    expect(deletes).toEqual(new Set([1n, 3n, 9n]))
+  })
+
+  it('loads puffin deletion vectors into position delete maps', async () => {
+    const referencedDataFile = 's3://bucket/table/data/a.parquet'
+    const blob = deletionVector([2n, 4n])
+    const file = puffinFile(blob, referencedDataFile)
+    const metadata = readPuffinMetadata(file)
+    const [blobMetadata] = metadata.blobs
+    const { positionDeletesMap } = await fetchDeleteMaps([{
+      status: 1,
+      sequence_number: 1n,
+      file_sequence_number: 1n,
+      data_file: {
+        content: 1,
+        file_path: 's3://bucket/table/metadata/dv.puffin',
+        file_format: 'puffin',
+        partition: {},
+        record_count: 2n,
+        file_size_in_bytes: BigInt(file.byteLength),
+        referenced_data_file: referencedDataFile,
+        content_offset: BigInt(blobMetadata.offset),
+        content_size_in_bytes: BigInt(blobMetadata.length),
+      },
+    }], {
+      reader() {
+        return asyncBuffer(file)
+      },
+    })
+
+    expect(positionDeletesMap.get(referencedDataFile)).toEqual(new Set([2n, 4n]))
+  })
+})
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {import('hyparquet').AsyncBuffer}
+ */
+function asyncBuffer(bytes) {
+  return {
+    byteLength: bytes.byteLength,
+    slice(start, end) {
+      const { buffer } = /** @type {{ buffer: ArrayBuffer }} */ (bytes)
+      return buffer.slice(bytes.byteOffset + start, end === undefined ? bytes.byteLength : bytes.byteOffset + end)
+    },
+  }
+}
+
+/**
+ * @param {Uint8Array} blob
+ * @param {string} referencedDataFile
+ * @returns {Uint8Array}
+ */
+function puffinFile(blob, referencedDataFile) {
+  const blobOffset = 4
+  const footer = {
+    blobs: [{
+      type: 'deletion-vector-v1',
+      fields: [],
+      'snapshot-id': -1,
+      'sequence-number': -1,
+      offset: blobOffset,
+      length: blob.byteLength,
+      properties: {
+        'referenced-data-file': referencedDataFile,
+        cardinality: '3',
+      },
+    }],
+  }
+  const footerPayload = new TextEncoder().encode(JSON.stringify(footer))
+  const out = new Uint8Array(4 + blob.byteLength + 4 + footerPayload.byteLength + 4 + 4 + 4)
+  const view = new DataView(out.buffer)
+  let offset = 0
+  view.setUint32(offset, 0x50464131, false)
+  offset += 4
+  out.set(blob, offset)
+  offset += blob.byteLength
+  view.setUint32(offset, 0x50464131, false)
+  offset += 4
+  out.set(footerPayload, offset)
+  offset += footerPayload.byteLength
+  view.setInt32(offset, footerPayload.byteLength, true)
+  offset += 4
+  view.setUint32(offset, 0, true)
+  offset += 4
+  view.setUint32(offset, 0x50464131, false)
+  return out
+}
+
+/**
+ * @param {bigint[]} positions
+ * @returns {Uint8Array}
+ */
+function deletionVector(positions) {
+  const byKey = new Map()
+  for (const pos of positions) {
+    const key = Number(pos >> 32n)
+    const value = Number(pos & 0xffffffffn)
+    const values = byKey.get(key) ?? []
+    values.push(value)
+    byKey.set(key, values)
+  }
+
+  const bitmaps = [...byKey.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([key, values]) => ({ key, bitmap: roaringArray(values) }))
+  const vectorLength = 8 + bitmaps.reduce((sum, { bitmap }) => sum + 4 + bitmap.byteLength, 0)
+  const vector = new Uint8Array(vectorLength)
+  const vectorView = new DataView(vector.buffer)
+  vectorView.setBigUint64(0, BigInt(bitmaps.length), true)
+  let vectorOffset = 8
+  for (const { key, bitmap } of bitmaps) {
+    vectorView.setUint32(vectorOffset, key, true)
+    vectorOffset += 4
+    vector.set(bitmap, vectorOffset)
+    vectorOffset += bitmap.byteLength
+  }
+
+  const payloadLength = 4 + vector.byteLength
+  const out = new Uint8Array(4 + payloadLength + 4)
+  const view = new DataView(out.buffer)
+  view.setUint32(0, payloadLength, false)
+  view.setUint32(4, 0xd1d33964, false)
+  out.set(vector, 8)
+  view.setUint32(out.byteLength - 4, crc32(out.subarray(4, out.byteLength - 4)), false)
+  return out
+}
+
+/**
+ * @param {number[]} values
+ * @returns {Uint8Array}
+ */
+function roaringArray(values) {
+  values = [...values].sort((a, b) => a - b)
+  const out = new Uint8Array(16 + values.length * 2)
+  const view = new DataView(out.buffer)
+  view.setUint32(0, 12346, true)
+  view.setUint32(4, 1, true)
+  view.setUint16(8, 0, true)
+  view.setUint16(10, values.length - 1, true)
+  view.setUint32(12, 16, true)
+  let offset = 16
+  for (const value of values) {
+    view.setUint16(offset, value, true)
+    offset += 2
+  }
+  return out
+}
+
+/**
+ * @param {number[]} values
+ * @returns {Uint8Array}
+ */
+function roaringBitmap(values) {
+  const out = new Uint8Array(16 + 8192)
+  const view = new DataView(out.buffer)
+  view.setUint32(0, 12346, true)
+  view.setUint32(4, 1, true)
+  view.setUint16(8, 0, true)
+  view.setUint16(10, values.length - 1, true)
+  view.setUint32(12, 16, true)
+  for (const value of values) {
+    const wordOffset = 16 + Math.floor(value / 64) * 8
+    const bit = BigInt(value % 64)
+    view.setBigUint64(wordOffset, view.getBigUint64(wordOffset, true) | 1n << bit, true)
+  }
+  return out
+}
+
+/**
+ * @param {[number, number][]} runs
+ * @returns {Uint8Array}
+ */
+function roaringRun(runs) {
+  const cardinality = runs.reduce((sum, [, length]) => sum + length, 0)
+  const out = new Uint8Array(4 + 1 + 4 + 2 + runs.length * 4)
+  const view = new DataView(out.buffer)
+  view.setUint32(0, 12347, true)
+  out[4] = 1
+  view.setUint16(5, 0, true)
+  view.setUint16(7, cardinality - 1, true)
+  view.setUint16(9, runs.length, true)
+  let offset = 11
+  for (const [start, length] of runs) {
+    view.setUint16(offset, start, true)
+    view.setUint16(offset + 2, length - 1, true)
+    offset += 4
+  }
+  return out
+}
+
+let crcTable
+
+/**
+ * @param {Uint8Array} bytes
+ * @returns {number}
+ */
+function crc32(bytes) {
+  crcTable ??= makeCrcTable()
+  let crc = 0xffffffff
+  for (const byte of bytes) {
+    crc = crcTable[(crc ^ byte) & 0xff] ^ crc >>> 8
+  }
+  crc = ~crc
+  return crc >>> 0
+}
+
+/**
+ * @returns {Uint32Array}
+ */
+function makeCrcTable() {
+  const table = new Uint32Array(256)
+  for (let i = 0; i < table.length; i++) {
+    let c = i
+    for (let j = 0; j < 8; j++) {
+      c = c & 1 ? 0xedb88320 ^ c >>> 1 : c >>> 1
+    }
+    table[i] = c >>> 0
+  }
+  return table
+}


### PR DESCRIPTION
## PR description

- Add Puffin file reader (`src/puffin/puffin.js`) that parses the file/footer magic, validates flags, and decodes the JSON footer payload to locate `deletion-vector-v1` blobs by offset/length.
- Implement `deletion-vector-v1` decoding (`src/puffin/deletion-vector.js`): 4-byte length + magic header, payload of `(key, roaring32)` pairs producing 64-bit positions, and CRC32 verification.
- Add a portable Roaring 32-bit bitmap reader (`src/puffin/roaring.js`) supporting array, bitmap, and run containers — no external dependency.
- Wire deletion vectors into `fetchDeleteMaps` in `src/fetch.js`: detect Puffin entries via `file_format === 'puffin'` or presence of `content_offset` / `content_size_in_bytes`, read the referenced blob, and merge positions into the existing `positionDeletesMap` keyed by `referenced_data_file`.
- Update README feature matrix: Puffin storage ⚠️ (uncompressed `deletion-vector-v1` only), Binary Deletion Vectors ✅, position-delete note expanded to cover Puffin.
