### PR TITLE
Icebird WRITER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Icebird Changelog
+
+## [0.4.0]
+ - Writer: `icebergCreateTable`, `icebergDropTable`, `icebergAppend`, `icebergDelete` with pluggable catalog type
+ - Puffin file reader and writer, including deletion vector support
+ - REST Catalog: create/drop/rename tables, register table, update table, create/delete namespaces, load credentials
+ - Partition support including hidden partitions and the Void transform
+ - Iceberg V3 types, row lineage, and V3 equality delete matching
+ - Sort order, geospatial stats, decimal types
+ - Parallelized data file reads
+ - `Resolver` / `Lister` abstraction for pluggable storage backends
+ - Async hyparquet writer
+ - Gzip metadata JSON support
+
+## [0.3.1]
+ - `icebergCreate` to create new Iceberg tables
+
+## [0.3.0]
+ - Avro writer
+ - Reorganize files in the repo
+
+## [0.2.0]
+ - Rename `IcebergMetadata` to `TableMetadata`
+ - Column projection for missing field ids
+ - Fix partition types
+
+## [0.1.15]
+ - V1 manifests default `sequence_number` to 0
+ - Fix sequence number inheritance
+
+## [0.1.14]
+ - `icebergListVersions`
+
+## [0.1.13]
+ - Support AWS Athena tables
+
+## [0.1.12]
+ - Authentication via `requestInit`
+ - Use `file_size_in_bytes` from metadata to skip HEAD request
+ - Fetch error handling
+ - Column rename support
+
+## [0.1.11]
+ - Avro logical types
+ - Only fetch delete maps once
+
+## [0.1.10]
+ - Fix equality deletes
+ - Inherit `sequence_number` on manifest entries
+
+## [0.1.0]
+ - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icebird",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Apache Iceberg client for javascript",
   "author": "Hyperparam",
   "homepage": "https://hyperparam.app",


### PR DESCRIPTION

### Read path
- Iceberg v3 reads: row lineage (`_row_id`, `_last_updated_sequence_number`), v3 types (variant, geometry, geography), Puffin deletion vectors, equality delete matching, delete partition scope
- Hidden + identity partition support, manifest-list partition pruning, parallelized data-file reads
- Gzip metadata JSON (`.gz.metadata.json`, `metadata.json.gz`)

### Write path (experimental, v2 + v3 deletion vectors)
- `icebergCreateTable`, `icebergDropTable`, `icebergAppend`, `icebergDelete`, `icebergSetRef`, `icebergExpireSnapshots`
- Generic `Catalog` abstraction — same calls work against `fileCatalog` or REST
- Position deletes as Parquet or Puffin deletion vectors; equality delete manifests
- Append/staged-commit flow with per-column stats, sort orders, partition spec evolution, fixed/decimal + geospatial stats, lower/upper bound truncation
- Honors `format-version`, `write.format.default`, `write.metadata.previous-versions-max`, `write-default`, compressor options
- Schema/spec updates: `add-schema`, `set-current-schema`, `add-spec`/`set-default-spec`, `set-properties`/`remove-properties`, full `assert-*` requirement checks, V3-only-type validation
- Async hyparquet writer, in-memory end-to-end test harness

### REST catalog
- Connect, list/load tables, create/drop/rename table, create/delete namespace, register table, update table, load credentials

### I/O
- New `Resolver`/`Lister` abstraction (pluggable storage); `urlResolver` ships `writer`/`deleter` for HTTP PUT/DELETE
- Auth now flows through `requestInit` on the resolver/lister rather than per-call (breaking)
