### PR TITLE
Implement scanColumn with where filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "hyparquet": "1.26.2",
     "hyparquet-compressors": "1.1.1",
     "hyparquet-writer": "0.16.1",
-    "squirreling": "0.12.27"
+    "squirreling": "0.15.0"
   },
   "devDependencies": {
     "@types/node": "26.1.0",

--- a/src/sql/icebergDataSource.js
+++ b/src/sql/icebergDataSource.js
@@ -7,7 +7,8 @@ import { fileMightMatch, partitionMightMatch } from '../prune.js'
 import { whereToParquetFilter } from './whereFilter.js'
 
 /**
- * @import {AsyncDataSource, SqlPrimitive} from 'squirreling'
+ * @import {AsyncDataSource, ExprNode, SqlPrimitive} from 'squirreling'
+ * @import {ScanColumnResults} from 'squirreling/src/types.js'
  * @import {Lister, Resolver, TableMetadata} from '../../src/types.js'
  */
 
@@ -202,45 +203,70 @@ export async function icebergDataSource({ tableUrl, metadataFileName, metadata, 
      * O(1)/O(cardinality) state; without the hook the engine falls back to
      * buffering every scanned row.
      *
-     * `scanColumn` is never given a WHERE (the engine only takes the streaming
-     * aggregate path when the scan has no filter), so there is no file or
-     * row-group pruning here, and there is no `appliedLimitOffset` flag to defer
-     * to: the source must fully honor LIMIT/OFFSET itself. Without deletes,
-     * record_count is exact, so whole files are skipped for OFFSET and the
-     * per-file read is bounded for LIMIT. With deletes, record_count is
-     * pre-delete, so OFFSET/LIMIT are applied over the post-delete value stream
-     * instead. `signal` aborts between chunks, mirroring `scan`.
+     * WHERE is pruned and pushed down exactly as in `scan`: whole data files
+     * are dropped by partition tuple and per-column manifest bounds, and the
+     * predicate is handed to hyparquet (row-group/page pruning plus per-row
+     * matching) when it fully converts to a parquet filter. Unsupported nodes
+     * (LIKE, functions, arithmetic) leave `appliedWhere: false` and the engine
+     * re-applies the predicate over the emitted values. `appliedLimitOffset`
+     * mirrors `scan`: OFFSET is pushed into the per-file seek and LIMIT bounds
+     * the read only when WHERE is fully resolved AND there is no WHERE, no
+     * deletes, and no pruning (position no longer tracks result rows
+     * otherwise); in every other case the source emits at most `offset+limit`
+     * values and the consumer applies the final slice. `signal` aborts between
+     * chunks, mirroring `scan`.
      *
      * @param {object} options
      * @param {string} options.column - Name of the single column to stream.
+     * @param {ExprNode} [options.where] - Row predicate; pruned/pushed when convertible.
      * @param {number} [options.limit] - Max number of values to yield.
      * @param {number} [options.offset] - Number of leading values to skip.
      * @param {AbortSignal} [options.signal] - Aborts the stream between chunks.
-     * @returns {AsyncIterable<ArrayLike<SqlPrimitive>>} Chunks of column values.
+     * @returns {ScanColumnResults} Column-value chunks plus applied-hint flags.
      */
-    scanColumn({ column, limit, offset, signal }) {
+    scanColumn({ column, where, limit, offset, signal }) {
       const wantedColumns = [column]
-      const skip = offset ?? 0
-      const take = limit ?? Infinity
+      // Mirror scan(): convert WHERE, prune files by manifest bounds, and only
+      // treat LIMIT/OFFSET as position-pushable when no WHERE is matched
+      // per-row, no deletes shift positions, and no file was pruned.
+      const filter = whereToParquetFilter(where)
+      const appliedWhere = where !== undefined && filter !== undefined
+      const scanEntries = filter
+        ? dataEntries.filter(entry =>
+          partitionMightMatch(filter, entry, schema, tableMetadata) &&
+            fileMightMatch(filter, entry, schema))
+        : dataEntries
+      const pruned = scanEntries.length < dataEntries.length
+      const whereResolved = !where || appliedWhere
+      const canPushOffset = !where && !hasDeletes && !pruned
+      const skip = canPushOffset ? offset ?? 0 : 0
+      let take = Infinity
+      if (whereResolved && limit !== undefined) {
+        take = canPushOffset ? limit : (offset ?? 0) + limit
+      }
+      const appliedLimitOffset = canPushOffset
       return {
-        async *[Symbol.asyncIterator]() {
+        appliedWhere,
+        appliedLimitOffset,
+        async *chunks() {
           if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
-          if (take === 0 || dataEntries.length === 0) return
+          if (take === 0 || scanEntries.length === 0) return
 
           const { positionDeletesMap, equalityDeleteGroups } = await deleteMapsPromise
 
           let remainingSkip = skip
           let remaining = take
-          for (const entry of dataEntries) {
+          for (const entry of scanEntries) {
             if (remaining <= 0) break
             if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
             const recordCount = Number(entry.data_file.record_count)
-            // Without deletes record_count counts visible rows, so skip whole
-            // files for OFFSET and bound the per-file end for LIMIT. With
-            // deletes it is pre-delete, so read each file whole and slice the
-            // post-delete batches below.
+            // Position-based file skip / per-file bound is only correct when
+            // canPushOffset holds; a matched WHERE, deletes, or pruning break
+            // the record_count-to-position mapping, so read whole files and
+            // let the value-stream slice below (and the consumer) apply the
+            // final LIMIT/OFFSET.
             let fileRowStart = 0
-            if (!hasDeletes && remainingSkip > 0) {
+            if (canPushOffset && remainingSkip > 0) {
               if (remainingSkip >= recordCount) {
                 remainingSkip -= recordCount
                 continue
@@ -248,7 +274,7 @@ export async function icebergDataSource({ tableUrl, metadataFileName, metadata, 
               fileRowStart = remainingSkip
               remainingSkip = 0
             }
-            const fileRowEnd = !hasDeletes && remaining !== Infinity
+            const fileRowEnd = canPushOffset && remaining !== Infinity
               ? Math.min(recordCount, fileRowStart + remaining)
               : recordCount
 
@@ -264,29 +290,21 @@ export async function icebergDataSource({ tableUrl, metadataFileName, metadata, 
               positionDeletesMap,
               equalityDeleteGroups,
               wantedColumns,
+              filter,
               signal,
             })) {
               if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
-              // Apply any OFFSET still owed in post-delete coordinates. Without
-              // deletes this is already spent at fileRowStart, so the guard is
-              // only reached when deletes are present.
-              let start = 0
-              if (remainingSkip > 0) {
-                if (remainingSkip >= batch.length) {
-                  remainingSkip -= batch.length
-                  continue
-                }
-                start = remainingSkip
-                remainingSkip = 0
-              }
+              // OFFSET is either already spent at fileRowStart (canPushOffset)
+              // or deferred to the consumer via appliedLimitOffset: false, so
+              // batches start at 0 here. `take` still caps the emitted count.
               let end = batch.length
-              if (remaining !== Infinity && end - start > remaining) {
-                end = start + remaining
+              if (remaining !== Infinity && end > remaining) {
+                end = remaining
                 stop = true
               }
               /** @type {SqlPrimitive[]} */
               const chunk = []
-              for (let i = start; i < end; i++) chunk.push(batch[i][column])
+              for (let i = 0; i < end; i++) chunk.push(batch[i][column])
               if (chunk.length > 0) {
                 yield chunk
                 remaining -= chunk.length

--- a/test/sql/icebergDataSource.test.js
+++ b/test/sql/icebergDataSource.test.js
@@ -5,6 +5,7 @@ import { localResolver } from '../helpers.js'
 
 /**
  * @import {AsyncDataSource, ExprNode} from 'squirreling'
+ * @import {ScanColumnResults} from 'squirreling/src/types.js'
  * @import {Resolver} from '../../src/types.js'
  */
 
@@ -480,22 +481,23 @@ describe.concurrent('icebergDataSource scanColumn', () => {
   const renameTableUrl = 's3://hyperparam-iceberg/spark/rename_column'
 
   /**
-   * Flatten a scanColumn stream into a single array of values, asserting each
+   * Flatten a scanColumn result into a single array of values, asserting each
    * yielded chunk is an array-like batch (the streaming/bounded-memory shape).
    *
-   * @param {AsyncIterable<ArrayLike<any>>} stream
-   * @returns {Promise<{ values: any[], chunks: number }>}
+   * @param {AsyncIterable<ArrayLike<any>> | ScanColumnResults} result
+   * @returns {Promise<{ values: any[], chunks: number, appliedWhere: boolean, appliedLimitOffset: boolean }>}
    */
-  async function drain(stream) {
+  async function drain(result) {
+    if (!('chunks' in result)) throw new Error('expected ScanColumnResults, got a bare AsyncIterable')
     /** @type {any[]} */
     const values = []
     let chunks = 0
-    for await (const chunk of stream) {
+    for await (const chunk of result.chunks()) {
       expect(typeof chunk.length).toBe('number')
       chunks++
       for (let i = 0; i < chunk.length; i++) values.push(chunk[i])
     }
-    return { values, chunks }
+    return { values, chunks, appliedWhere: result.appliedWhere, appliedLimitOffset: result.appliedLimitOffset }
   }
 
   /**
@@ -577,7 +579,7 @@ describe.concurrent('icebergDataSource scanColumn', () => {
     expect(cappedChunks).toBe(2)
   })
 
-  it('applies LIMIT/OFFSET over post-delete values when deletes are present', async () => {
+  it('defers LIMIT/OFFSET to the consumer when deletes are present', async () => {
     const source = await icebergDataSource({ tableUrl, resolver, metadataFileName: 'v4.metadata.json' })
     const full = await scanColumnOracle(source, 'Breed Name')
     expect(full).toHaveLength(15)
@@ -588,11 +590,16 @@ describe.concurrent('icebergDataSource scanColumn', () => {
     const { values: all } = await drain(scanColumn({ column: 'Breed Name' }))
     expect(all).toEqual(full)
 
-    // LIMIT/OFFSET are post-delete coordinates (record_count is pre-delete), so
-    // they must align with slices of the post-delete oracle, not raw files.
+    // record_count is pre-delete, so position-based OFFSET/LIMIT no longer
+    // tracks post-delete result rows: the source declines the pushdown
+    // (appliedLimitOffset: false), emits the leading offset+limit post-delete
+    // values, and the consumer applies the final slice.
     for (const [offset, limit] of [[0, 1], [4, 2], [8, 4], [13, 5]]) {
-      const { values } = await drain(scanColumn({ column: 'Breed Name', offset, limit }))
-      expect(values).toEqual(full.slice(offset, offset + limit))
+      const { values, appliedLimitOffset } = await drain(scanColumn({ column: 'Breed Name', offset, limit }))
+      expect(appliedLimitOffset).toBe(false)
+      expect(values).toEqual(full.slice(0, offset + limit))
+      // The consumer's slice over the emitted prefix recovers the intended window.
+      expect(values.slice(offset, offset + limit)).toEqual(full.slice(offset, offset + limit))
     }
   })
 
@@ -618,7 +625,9 @@ describe.concurrent('icebergDataSource scanColumn', () => {
     if (!scanColumn) throw new Error('scanColumn not implemented')
 
     const controller = new AbortController()
-    const iterator = scanColumn({ column: 'id', signal: controller.signal })[Symbol.asyncIterator]()
+    const result = scanColumn({ column: 'id', signal: controller.signal })
+    if (!('chunks' in result)) throw new Error('expected ScanColumnResults, got a bare AsyncIterable')
+    const iterator = result.chunks()[Symbol.asyncIterator]()
 
     const first = await iterator.next()
     expect(first.done).toBe(false)
@@ -626,6 +635,98 @@ describe.concurrent('icebergDataSource scanColumn', () => {
 
     controller.abort()
     await expect(iterator.next()).rejects.toThrow('Aborted')
+  })
+
+  /**
+   * @param {string} column
+   * @param {'='|'>'|'<'|'>='|'<='} op
+   * @param {any} value
+   * @returns {ExprNode}
+   */
+  function cmp(column, op, value) {
+    return /** @type {ExprNode} */ ({
+      type: 'binary', op, left: { type: 'identifier', name: column }, right: { type: 'literal', value },
+    })
+  }
+
+  /**
+   * Filtered oracle: the same single column read via scan() with a WHERE, which
+   * icebird already prunes and matches per row. scanColumn's pushdown must agree.
+   *
+   * @param {AsyncDataSource} source
+   * @param {string} column
+   * @param {ExprNode} where
+   * @returns {Promise<any[]>}
+   */
+  async function scanColumnFilteredOracle(source, column, where) {
+    /** @type {any[]} */
+    const out = []
+    for await (const row of source.scan({ columns: [column], where }).rows()) {
+      out.push((row.resolved ?? {})[column])
+    }
+    return out
+  }
+
+  it('pushes a convertible WHERE down: filters values and reports appliedWhere', async () => {
+    const source = await icebergDataSource({ tableUrl, resolver, metadataFileName: 'v2.metadata.json' })
+    const { scanColumn } = source
+    if (!scanColumn) throw new Error('scanColumn not implemented')
+
+    const where = cmp('Popularity Rank', '>', 15n)
+    const expected = await scanColumnFilteredOracle(source, 'Popularity Rank', where)
+    // Genuinely selective: some rows kept, some dropped (ranks 16..21 of 1..21).
+    expect(expected).toHaveLength(6)
+
+    const { values, appliedWhere, appliedLimitOffset } = await drain(scanColumn({ column: 'Popularity Rank', where }))
+    expect(appliedWhere).toBe(true) // convertible predicate, honestly applied at the leaf
+    expect(appliedLimitOffset).toBe(false) // per-row WHERE breaks position pushdown
+    expect([...values].sort()).toEqual([...expected].sort()) // only matching rows emitted
+  })
+
+  it('declines a WHERE it cannot convert (appliedWhere:false, emits every value)', async () => {
+    const source = await icebergDataSource({ tableUrl, resolver, metadataFileName: 'v2.metadata.json' })
+    const { scanColumn } = source
+    if (!scanColumn) throw new Error('scanColumn not implemented')
+
+    // identifier-vs-identifier is not convertible to a parquet filter, so the
+    // source must decline: emit everything and leave the predicate to the engine.
+    const where = /** @type {ExprNode} */ ({
+      type: 'binary', op: '=',
+      left: { type: 'identifier', name: 'Breed Name' },
+      right: { type: 'identifier', name: 'Breed Name' },
+    })
+    const full = await scanColumnOracle(source, 'Breed Name')
+    const { values, appliedWhere } = await drain(scanColumn({ column: 'Breed Name', where }))
+    expect(appliedWhere).toBe(false)
+    expect(values).toEqual(full) // unfiltered; engine re-applies the WHERE
+  })
+
+  it('lights the streaming aggregate fast path with a pushed-down WHERE', async () => {
+    const source = await icebergDataSource({ tableUrl, resolver, metadataFileName: 'v2.metadata.json' })
+    const baseScanColumn = source.scanColumn
+    if (!baseScanColumn) throw new Error('scanColumn not implemented')
+
+    // Prove the engine hands the WHERE to scanColumn (pushdown), not just to the
+    // buffering scan() fallback.
+    let sawWhere = false
+    /** @type {AsyncDataSource} */
+    const spied = {
+      ...source,
+      /** @type {NonNullable<AsyncDataSource['scanColumn']>} */
+      scanColumn(options) {
+        if (options.where !== undefined) sawWhere = true
+        return baseScanColumn(options)
+      },
+    }
+
+    const result = await collect(executeSql({
+      tables: { bunnies: spied },
+      query: 'SELECT COUNT(*) AS c FROM bunnies WHERE "Popularity Rank" > 15',
+    }))
+
+    expect(sawWhere).toBe(true)
+    expect(result).toHaveLength(1)
+    expect(Number(result[0].c)).toBe(6) // ranks 16..21
   })
 
   it('lights squirreling\'s streaming scalar-aggregate fast path', async () => {


### PR DESCRIPTION
## Summary

Extends the `scanColumn` streaming path in `icebergDataSource` to accept and push down a `WHERE` predicate, matching how `scan` already handles filtering. Previously `scanColumn` was only used when a scan had no filter; now the engine can take the streaming aggregate fast path even with a `WHERE` clause.

- **File & row-group pruning**: whole data files are dropped by partition tuple and per-column manifest bounds, and the predicate is handed to hyparquet for row-group/page pruning plus per-row matching when it fully converts to a parquet filter.
- **Honest applied-hint flags**: returns `appliedWhere` / `appliedLimitOffset` so the engine knows whether to re-apply the predicate or slice. Unsupported nodes (LIKE, functions, arithmetic, identifier-vs-identifier) leave `appliedWhere: false` and the engine re-applies.
- **LIMIT/OFFSET pushdown** is only claimed when it's still position-correct — no WHERE matched per-row, no deletes, and no file pruned. Otherwise the source emits at most `offset+limit` values and the consumer applies the final slice.
- Bumps `squirreling` 0.12.27 → 0.15.0 for the `ScanColumnResults` shape (`chunks()` + flag fields).

## Testing

- `npm test` — 591 passing
- New tests cover: convertible WHERE pushdown, declining a non-convertible WHERE, the streaming aggregate fast path lighting up with a pushed-down WHERE, and LIMIT/OFFSET deferral when deletes are present.