### PR TITLE
Add icebergUpdateSchema for schema evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ import {
   icebergExpireSnapshots,
   icebergRewrite,
   icebergSetRef,
+  icebergUpdateSchema,
 } from 'icebird'
 
 // `urlResolver()` ships with a `writer` (HTTP PUT) and `deleter` (HTTP DELETE);
@@ -173,6 +174,21 @@ await icebergDelete({
 // snapshot management
 await icebergSetRef({ catalog, tableUrl, ref: 'main', snapshotId })
 await icebergExpireSnapshots({ catalog, tableUrl, snapshotIds: [oldSnapshotId] })
+
+// schema evolution — pass the complete evolved schema; existing columns keep
+// their field ids, new columns use ids above the table's `last-column-id`.
+// Metadata-only: existing data files read the new column as `null`.
+await icebergUpdateSchema({
+  catalog, tableUrl,
+  schema: {
+    type: 'struct',
+    'schema-id': 0, // ignored; the next schema id is assigned at commit
+    fields: [
+      ...schema.fields,
+      { id: 3, name: 'score', required: false, type: 'double' },
+    ],
+  },
+})
 ```
 
 If the table is created with a `sortOrder`, `icebergAppend` orders the rows in each written file by that order (tightening per-file column bounds for scan pruning). `icebergRewrite` compacts the current snapshot — reading every live row (deletes applied), sorting globally, and rewriting into consolidated, non-overlapping files via a `replace` snapshot (v2 tables):

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { IcebergTransactionConflictError, icebergAppend, icebergCreateTable, icebergDelete, icebergDropTable, icebergExpireSnapshots, icebergRewrite, icebergSetRef, icebergTransaction } from './write/write.js'
+export { IcebergTransactionConflictError, icebergAppend, icebergCreateTable, icebergDelete, icebergDropTable, icebergExpireSnapshots, icebergRewrite, icebergSetRef, icebergTransaction, icebergUpdateSchema } from './write/write.js'
 export { icebergCreate } from './create.js'
 export { fileCatalog } from './catalog/file.js'
 export { restCatalogConnect, restCatalogCreateNamespace, restCatalogDropNamespace, restCatalogListNamespaces, restCatalogListTables, restCatalogLoadCredentials, restCatalogLoadTable, restCatalogRegisterTable, restCatalogRenameTable } from './catalog/rest.js'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -318,15 +318,25 @@ export interface IcebergTransaction {
 }
 
 /**
- * Output of an `icebergStage*` call: the snapshot just produced, the CAS
- * preconditions and updates a catalog must apply, and the data/manifest files
- * already written to storage (useful for cleanup on commit failure).
+ * Input to a commit function (`fileCatalogCommit`, `restCatalogUpdateTable`):
+ * the CAS preconditions and updates a catalog must apply, and the
+ * data/manifest files already written to storage (useful for cleanup on
+ * commit failure). `snapshot` is absent for metadata-only updates like a
+ * schema change.
  */
-export interface StagedUpdate {
-  snapshot: Snapshot
+export interface StagedCommit {
+  snapshot?: Snapshot
   requirements: TableRequirement[]
   updates: TableUpdate[]
   writtenFiles: string[]
+}
+
+/**
+ * Output of an `icebergStage*` call that produces a snapshot (append, delete,
+ * rewrite, setRef, expireSnapshots).
+ */
+export interface StagedUpdate extends StagedCommit {
+  snapshot: Snapshot
 }
 
 /**

--- a/src/write/commit.js
+++ b/src/write/commit.js
@@ -4,11 +4,11 @@ import { parseDecimalType } from './conversions.js'
 import { validatePartitionSpecForWrite } from './partition.js'
 
 /**
- * @import {Field, IcebergType, PartitionSpec, Resolver, Schema, SnapshotRef, SortOrder, StagedUpdate, TableMetadata, TableRequirement, TableUpdate} from '../../src/types.js'
+ * @import {Field, IcebergType, PartitionSpec, Resolver, Schema, SnapshotRef, SortOrder, StagedCommit, TableMetadata, TableRequirement, TableUpdate} from '../../src/types.js'
  */
 
 /**
- * Commit a `StagedUpdate` against a file-based catalog: verify requirements
+ * Commit a `StagedCommit` against a file-based catalog: verify requirements
  * against the current metadata, apply updates, and write the next
  * `vN.metadata.json` and `version-hint.text`.
  *
@@ -30,7 +30,7 @@ import { validatePartitionSpecForWrite } from './partition.js'
  *   prior version so rollback / log walks land on a real file even when the
  *   prior writer used `NNNNN-<uuid>.metadata.json` instead of `vN.metadata.json`.
  * @param {number} [options.currentVersion] - If known, the on-disk version of `metadata`. Bypasses deriving from `metadata-log`, which can be empty/stale on foreign-written tables.
- * @param {StagedUpdate} options.staged
+ * @param {StagedCommit} options.staged
  * @param {Resolver} options.resolver
  * @param {boolean} [options.conditionalCommits] - When true, write the metadata file with `ifNoneMatch: '*'`.
  * @returns {Promise<TableMetadata>} The new metadata, already persisted.

--- a/src/write/stage.js
+++ b/src/write/stage.js
@@ -1,5 +1,6 @@
 import { validateSchemaForVersion } from '../schema.js'
 import { uuid4 } from '../utils.js'
+import { applyUpdates } from './commit.js'
 import { writeParquet } from './parquet.js'
 import { writeDataManifest } from './manifest.js'
 import { groupByPartition } from './partition.js'
@@ -13,7 +14,7 @@ import { computeColumnStats } from './stats.js'
 
 /**
  * @import {CompressionCodec} from 'hyparquet'
- * @import {FieldSummary, Manifest, PreparedAppend, Resolver, Snapshot, StagedUpdate, TableMetadata, TableRequirement, TableUpdate} from '../../src/types.js'
+ * @import {FieldSummary, Manifest, PreparedAppend, Resolver, Schema, Snapshot, StagedCommit, StagedUpdate, TableMetadata, TableRequirement, TableUpdate} from '../../src/types.js'
  */
 
 /**
@@ -367,10 +368,8 @@ export function icebergStageExpireSnapshots({ metadata, snapshotIds }) {
   /** @type {TableUpdate} */
   const update = { action: 'remove-snapshots', 'snapshot-ids': snapshotIds }
 
-  // The snapshot field on StagedUpdate is non-optional; surface the current
-  // snapshot so callers reading `staged.snapshot` after an expire still see
-  // the live tip. Synthesize a minimal placeholder for tables with no
-  // snapshots left after the operation.
+  // Surface the current snapshot so callers reading `staged.snapshot` after
+  // an expire (e.g. `icebergTransaction`) still see the live tip.
   const tip = currentSnapshot(metadata) ?? snapshots[0]
   if (!tip) throw new Error('cannot expire snapshots from a table with no snapshots')
 
@@ -378,6 +377,56 @@ export function icebergStageExpireSnapshots({ metadata, snapshotIds }) {
     snapshot: tip,
     requirements,
     updates: [update],
+    writtenFiles: [],
+  }
+}
+
+/**
+ * Stage a schema update: add `schema` as a new schema and make it current.
+ * This is the schema-evolution primitive — add a column, rename a column,
+ * promote a type — expressed as the full evolved schema.
+ *
+ * The caller supplies the complete new schema with field ids assigned:
+ * existing columns keep their ids, new columns use ids above
+ * `last-column-id`. The `schema-id` is assigned at commit time via the spec
+ * sentinel `-1`, so any `schema-id` on the input is ignored. Evolution rules
+ * (no field-id reuse, valid type promotions, immutable `initial-default`,
+ * required new fields need defaults) are validated here against the loaded
+ * metadata and again at commit.
+ *
+ * Pure: produces a metadata-only `StagedCommit` (no snapshot, no files) to
+ * pass into a commit function (`fileCatalogCommit`, `restCatalogUpdateTable`).
+ *
+ * @param {object} options
+ * @param {TableMetadata} options.metadata - Current table metadata.
+ * @param {Schema} options.schema - The complete evolved schema.
+ * @returns {StagedCommit}
+ */
+export function icebergStageUpdateSchema({ metadata, schema }) {
+  if (!schema || schema.type !== 'struct' || !Array.isArray(schema.fields)) {
+    throw new Error('schema must be a struct with a fields array')
+  }
+
+  /** @type {TableRequirement[]} */
+  const requirements = [
+    { type: 'assert-table-uuid', uuid: metadata['table-uuid'] },
+    { type: 'assert-current-schema-id', 'current-schema-id': metadata['current-schema-id'] },
+    { type: 'assert-last-assigned-field-id', 'last-assigned-field-id': metadata['last-column-id'] },
+  ]
+
+  /** @type {TableUpdate[]} */
+  const updates = [
+    { action: 'add-schema', schema: { ...schema, 'schema-id': -1 } },
+    { action: 'set-current-schema', 'schema-id': -1 },
+  ]
+
+  // Fail fast at stage time: applyUpdates enforces the schema-evolution rules
+  // that would otherwise only surface at commit (server-side for REST).
+  applyUpdates(metadata, updates)
+
+  return {
+    requirements,
+    updates,
     writtenFiles: [],
   }
 }

--- a/src/write/write.js
+++ b/src/write/write.js
@@ -5,11 +5,11 @@ import { loadLatestFileCatalogMetadata } from '../metadata.js'
 import { applyUpdates, fileCatalogCommit } from './commit.js'
 import { icebergStageDeletionVector } from './stage-deletion-vector.js'
 import { icebergStagePositionDelete } from './stage-position-delete.js'
-import { icebergStageAppend, icebergStageExpireSnapshots, icebergStageSetRef, prepareAppend, stageSnapshotForAppend } from './stage.js'
+import { icebergStageAppend, icebergStageExpireSnapshots, icebergStageSetRef, icebergStageUpdateSchema, prepareAppend, stageSnapshotForAppend } from './stage.js'
 import { icebergStageRewrite } from './rewrite.js'
 
 /**
- * @import {Catalog, IcebergTransaction, Lister, PartitionSpec, Resolver, Schema, Snapshot, SortOrder, StagedUpdate, TableMetadata, TableRequirement, TableUpdate} from '../../src/types.js'
+ * @import {Catalog, IcebergTransaction, Lister, PartitionSpec, Resolver, Schema, Snapshot, SortOrder, StagedCommit, StagedUpdate, TableMetadata, TableRequirement, TableUpdate} from '../../src/types.js'
  */
 
 const DEFAULT_RETRY = Object.freeze({
@@ -174,6 +174,33 @@ export async function icebergSetRef({
       maxSnapshotAgeMs,
       maxRefAgeMs,
     }),
+  })
+}
+
+/**
+ * Evolve the table schema: add `schema` as a new schema version and make it
+ * current. Use it to add columns, rename columns, or promote types — pass the
+ * complete evolved schema with existing field ids preserved and new columns
+ * using ids above the table's `last-column-id`.
+ *
+ * Metadata-only: no data files are rewritten. Existing data files read the
+ * new columns as `null` (or their `initial-default`), and subsequent appends
+ * write with the evolved schema.
+ *
+ * @param {object} options
+ * @param {Catalog} options.catalog
+ * @param {string | string[]} [options.namespace] - REST catalog only.
+ * @param {string} [options.table] - REST catalog only.
+ * @param {string} [options.tableUrl] - File catalog only.
+ * @param {Resolver} [options.resolver]
+ * @param {Schema} options.schema - The complete evolved schema.
+ * @returns {Promise<TableMetadata>}
+ */
+export async function icebergUpdateSchema({ catalog, namespace, table, tableUrl, resolver, schema }) {
+  const ctx = await loadTable({ catalog, namespace, table, tableUrl, resolver })
+  return await commitWithRetry({
+    catalog, target: { namespace, table }, ctx,
+    stage: workingCtx => icebergStageUpdateSchema({ metadata: workingCtx.metadata, schema }),
   })
 }
 
@@ -499,7 +526,7 @@ function requireResolver(resolver, caller) {
  * @param {Catalog} catalog
  * @param {{namespace?: string | string[], table?: string}} target
  * @param {{metadata: TableMetadata, metadataFileName: string | undefined, version?: number, tableUrl: string, resolver: Resolver | undefined}} ctx
- * @param {StagedUpdate} staged
+ * @param {StagedCommit} staged
  * @returns {Promise<TableMetadata>}
  */
 async function commitStaged(catalog, target, ctx, staged) {
@@ -552,7 +579,7 @@ async function commitStaged(catalog, target, ctx, staged) {
  * @param {Catalog} options.catalog
  * @param {{namespace?: string | string[], table?: string}} options.target
  * @param {{metadata: TableMetadata, metadataFileName: string | undefined, version?: number, tableUrl: string, resolver: Resolver | undefined}} options.ctx - The initial loaded ctx; refreshed on retry.
- * @param {(workingCtx: {metadata: TableMetadata, metadataFileName: string | undefined, version?: number, tableUrl: string, resolver: Resolver | undefined}) => Promise<StagedUpdate> | StagedUpdate} options.stage
+ * @param {(workingCtx: {metadata: TableMetadata, metadataFileName: string | undefined, version?: number, tableUrl: string, resolver: Resolver | undefined}) => Promise<StagedCommit> | StagedCommit} options.stage
  * @returns {Promise<TableMetadata>}
  */
 async function commitWithRetry({ catalog, target, ctx, stage }) {

--- a/test/write/update-schema.test.js
+++ b/test/write/update-schema.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fileCatalog } from '../../src/catalog/file.js'
+import { icebergCreate } from '../../src/create.js'
+import { icebergRead } from '../../src/read.js'
+import { icebergStageUpdateSchema } from '../../src/write/stage.js'
+import { icebergAppend, icebergUpdateSchema } from '../../src/write/write.js'
+import { memResolver } from '../helpers.js'
+
+/**
+ * @import {Schema} from '../../src/types.js'
+ */
+
+/** @type {Schema} */
+const schema = {
+  type: 'struct',
+  'schema-id': 0,
+  fields: [
+    { id: 1, name: 'id', required: true, type: 'long' },
+    { id: 2, name: 'name', required: false, type: 'string' },
+  ],
+}
+
+/** @type {Schema} */
+const evolvedSchema = {
+  type: 'struct',
+  'schema-id': 0,
+  fields: [
+    { id: 1, name: 'id', required: true, type: 'long' },
+    { id: 2, name: 'name', required: false, type: 'string' },
+    { id: 3, name: 'score', required: false, type: 'double' },
+  ],
+}
+
+describe('icebergUpdateSchema', () => {
+  it('adds a nullable column and round-trips: old rows read null, new appends use the evolved schema', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+    const tableUrl = 'http://test/update-schema1'
+    const { resolver } = memResolver()
+    const catalog = fileCatalog({ resolver })
+
+    await icebergCreate({ tableUrl, resolver, schema })
+    await icebergAppend({ catalog, tableUrl, records: [{ id: 1n, name: 'alice' }] })
+
+    const updated = await icebergUpdateSchema({ catalog, tableUrl, schema: evolvedSchema })
+
+    expect(updated.schemas).toHaveLength(2)
+    expect(updated['current-schema-id']).toBe(1)
+    expect(updated.schemas?.[1]['schema-id']).toBe(1)
+    expect(updated.schemas?.[1].fields.map(f => f.id)).toEqual([1, 2, 3])
+    expect(updated['last-column-id']).toBe(3)
+    // metadata-only commit: no new snapshot
+    expect(updated.snapshots).toHaveLength(1)
+
+    const committed = await icebergAppend({
+      catalog, tableUrl, records: [{ id: 2n, name: 'bob', score: 9.5 }],
+    })
+
+    const read = await icebergRead({ tableUrl, metadata: committed, resolver })
+    expect(read).toEqual([
+      { id: 1n, name: 'alice', score: null },
+      { id: 2n, name: 'bob', score: 9.5 },
+    ])
+  })
+
+  it('renames a column in place: old data reads under the new name via field id', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
+    const tableUrl = 'http://test/update-schema2'
+    const { resolver } = memResolver()
+    const catalog = fileCatalog({ resolver })
+
+    await icebergCreate({ tableUrl, resolver, schema })
+    await icebergAppend({ catalog, tableUrl, records: [{ id: 1n, name: 'alice' }] })
+
+    /** @type {Schema} */
+    const renamed = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'id', required: true, type: 'long' },
+        { id: 2, name: 'full_name', required: false, type: 'string' },
+      ],
+    }
+    const updated = await icebergUpdateSchema({ catalog, tableUrl, schema: renamed })
+
+    expect(updated['last-column-id']).toBe(2)
+    const read = await icebergRead({ tableUrl, metadata: updated, resolver })
+    expect(read).toEqual([{ id: 1n, full_name: 'alice' }])
+  })
+
+  it('rejects reusing an existing field id with an incompatible type', async () => {
+    const tableUrl = 'http://test/update-schema3'
+    const { resolver } = memResolver()
+    const catalog = fileCatalog({ resolver })
+
+    await icebergCreate({ tableUrl, resolver, schema })
+    /** @type {Schema} */
+    const bad = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'id', required: true, type: 'long' },
+        { id: 2, name: 'name', required: false, type: 'double' },
+      ],
+    }
+    await expect(icebergUpdateSchema({ catalog, tableUrl, schema: bad }))
+      .rejects.toThrow(/cannot promote field name from string to double/)
+  })
+
+  it('rejects a new required column without defaults', async () => {
+    const tableUrl = 'http://test/update-schema4'
+    const { resolver } = memResolver()
+    const catalog = fileCatalog({ resolver })
+
+    await icebergCreate({ tableUrl, resolver, schema })
+    /** @type {Schema} */
+    const bad = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        ...schema.fields,
+        { id: 3, name: 'score', required: true, type: 'double' },
+      ],
+    }
+    await expect(icebergUpdateSchema({ catalog, tableUrl, schema: bad }))
+      .rejects.toThrow(/required field score \(id 3\) needs a non-null initial-default/)
+  })
+})
+
+describe('icebergStageUpdateSchema', () => {
+  const metadata = /** @type {any} */ ({
+    'format-version': 2,
+    'table-uuid': 'uuid-1',
+    'current-schema-id': 0,
+    'last-column-id': 2,
+    schemas: [schema],
+  })
+
+  it('stages add-schema + set-current-schema with CAS requirements and no snapshot', () => {
+    const staged = icebergStageUpdateSchema({ metadata, schema: evolvedSchema })
+
+    expect(staged.snapshot).toBeUndefined()
+    expect(staged.writtenFiles).toEqual([])
+    expect(staged.requirements).toEqual([
+      { type: 'assert-table-uuid', uuid: 'uuid-1' },
+      { type: 'assert-current-schema-id', 'current-schema-id': 0 },
+      { type: 'assert-last-assigned-field-id', 'last-assigned-field-id': 2 },
+    ])
+    expect(staged.updates).toEqual([
+      { action: 'add-schema', schema: { ...evolvedSchema, 'schema-id': -1 } },
+      { action: 'set-current-schema', 'schema-id': -1 },
+    ])
+  })
+
+  it('throws when schema is not a struct with fields', () => {
+    // @ts-expect-error
+    expect(() => icebergStageUpdateSchema({ metadata, schema: undefined }))
+      .toThrow(/schema must be a struct with a fields array/)
+    // @ts-expect-error
+    expect(() => icebergStageUpdateSchema({ metadata, schema: { type: 'struct' } }))
+      .toThrow(/schema must be a struct with a fields array/)
+  })
+
+  it('throws at stage time when a new field id skips past last-column-id validation', () => {
+    /** @type {Schema} */
+    const bad = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'id', required: true, type: 'long' },
+        { id: 2, name: 'renamed', required: false, type: 'double' },
+      ],
+    }
+    expect(() => icebergStageUpdateSchema({ metadata, schema: bad }))
+      .toThrow(/cannot promote/)
+  })
+})


### PR DESCRIPTION
Fixes #25

Exposes the existing `add-schema` / `set-current-schema` commit logic through a stable public entry point, so consumers can add nullable columns (or rename columns, promote types) to an existing table in place — no recreate-and-reload.

## Changes

- **`icebergStageUpdateSchema({ metadata, schema })`** (`stage.js`) — pure, metadata-only stage emitting `add-schema` (spec sentinel `schema-id: -1`) + `set-current-schema`, guarded by `assert-table-uuid`, `assert-current-schema-id`, and `assert-last-assigned-field-id` CAS requirements. Runs `applyUpdates` eagerly so evolution violations (field-id reuse, illegal type promotion, required column without defaults) fail at stage time rather than only at commit / server-side.
- **`icebergUpdateSchema({ catalog, ..., schema })`** (`write.js`) — top-level commit through `commitWithRetry`; retry-safe since it writes no data files. Works for file and REST catalogs.
- **`StagedCommit`** supertype (`types.d.ts`) with optional `snapshot` for metadata-only commits; `StagedUpdate` extends it and keeps `snapshot` required for the snapshot-producing stages, so existing callers and tests are unaffected.
- Exported from `index.js`, documented in the README.

## API

The caller passes the complete evolved schema with field ids assigned: existing columns keep their ids, new columns use ids above the table's `last-column-id` (matches HypAware's `mergeFieldIdsFromTable`). The new schema's id is assigned at commit time.

```js
await icebergUpdateSchema({
  catalog, tableUrl,
  schema: {
    type: 'struct',
    'schema-id': 0, // ignored; assigned at commit
    fields: [
      ...schema.fields,
      { id: 3, name: 'score', required: false, type: 'double' },
    ],
  },
})
```

## Acceptance criteria from #25

- ✅ Add a nullable column to an existing table and commit it, no recreate
- ✅ Subsequent appends use the evolved schema (staging reads `current-schema-id`)
- ✅ Pre-existing files read the new column as `null` (existing read-path null-fill)
- ✅ Field ids preserved for existing columns, assigned by caller for new ones
- ✅ Round-trip test: create → append → add column → append → read all back, old rows `null` in the new column

## Testing

7 new tests in `test/write/update-schema.test.js`: the round-trip above, rename-by-field-id, rejection of incompatible type changes and defaultless required columns, and the staged requirements/updates shape. `npx tsc`, `npm run lint`, and all 598 tests pass.