### PR TITLE
String bounds pruning: truncated bounds are valid outer bounds

### DIFF
--- a/src/prune.js
+++ b/src/prune.js
@@ -1,6 +1,6 @@
 import { typeName } from './schema.js'
 import { applyTransform } from './write/transform.js'
-import { compare, deserializeValue } from './write/serde.js'
+import { compare, compareStringsCodePoint, deserializeValue } from './write/serde.js'
 
 /**
  * Partition-level scan pruning. Given a hyparquet query filter (keyed by
@@ -325,9 +325,10 @@ function equals(a, b) {
 
 /**
  * Order two partition values. Returns -1/0/1, or undefined when the values are
- * not safely orderable. Strings and booleans are intentionally not ordered
- * (JS UTF-16 order can differ from Iceberg's UTF-8 order), so range predicates
- * on them never prune.
+ * not safely orderable. Strings order by code point, which matches Iceberg's
+ * UTF-8 byte order (JS `<` compares UTF-16 code units and disagrees, which is
+ * why they were previously not ordered here). Booleans are intentionally not
+ * ordered, so range predicates on them never prune.
  *
  * @param {any} a
  * @param {any} b
@@ -342,6 +343,7 @@ function compareOrder(a, b) {
   if (aDate && bDate) return sign(a.getTime() - b.getTime())
 
   if (typeof a === 'bigint' && typeof b === 'bigint') return a < b ? -1 : a > b ? 1 : 0
+  if (typeof a === 'string' && typeof b === 'string') return compareStringsCodePoint(a, b)
 
   const na = numericOf(a)
   const nb = numericOf(b)
@@ -385,9 +387,14 @@ function sign(n) {
 function boundsMightMatch(column, condition, dataFile, schema) {
   const field = schema.fields.find(f => f.name === column)
   if (!field) return true
-  // Bounds and metric ordering are only defined for orderable scalar types.
-  // String/binary/fixed/uuid bounds are truncated prefixes, so we never use
-  // them for pruning (equality on a truncated prefix is undecidable).
+  // Bounds pruning needs a totally ordered type. String/binary/fixed/uuid
+  // bounds may be truncated prefixes (Iceberg's `truncate(16)` metrics), but
+  // truncation preserves them as OUTER bounds: a truncated lower bound is a
+  // prefix of the minimum (byte order <= min), a truncated upper bound has its
+  // last unit incremented (>= max) or is omitted entirely when incrementing
+  // overflows. Every skip below requires the predicate to be provably outside
+  // [lo, hi], which outer bounds only ever widen, so pruning stays safe; only
+  // $ne/$nin would need exact single-value bounds, and those already keep.
   if (!isOrderableForBounds(field.type)) return true
 
   const lowerBytes = boundForField(dataFile.lower_bounds, field.id)
@@ -423,16 +430,20 @@ function boundForField(map, fieldId) {
 }
 
 /**
- * Whether a type has totally-ordered, untruncated single-value bounds suitable
- * for range/equality pruning. String/binary/fixed/uuid are excluded because
- * their bounds are stored truncated.
+ * Whether a type has totally-ordered bounds suitable for range/equality
+ * pruning. The byte-ordered family (string/binary/fixed/uuid) qualifies even
+ * though its bounds may be truncated prefixes: truncation keeps them valid
+ * outer bounds (see boundsMightMatch), and `compare` orders strings by code
+ * point, which matches the UTF-8 byte order the bounds were chosen under.
+ * Excluded are only types with no defined value order (struct, list, map,
+ * variant, geometry).
  *
  * @param {IcebergType} type
  * @returns {boolean}
  */
 function isOrderableForBounds(type) {
   const name = typeName(type)
-  if (name.startsWith('decimal(')) return true
+  if (name.startsWith('decimal(') || name.startsWith('fixed[')) return true
   switch (name) {
   case 'boolean':
   case 'int':
@@ -445,6 +456,9 @@ function isOrderableForBounds(type) {
   case 'timestamptz':
   case 'timestamp_ns':
   case 'timestamptz_ns':
+  case 'string':
+  case 'binary':
+  case 'uuid':
     return true
   default:
     return false

--- a/src/write/serde.js
+++ b/src/write/serde.js
@@ -199,7 +199,7 @@ export function compare(a, b, type) {
   case 'timestamptz_ns':
     return compareBigInt(timestampToNanos(a), timestampToNanos(b))
   case 'string':
-    return a < b ? -1 : a > b ? 1 : 0
+    return compareStringsCodePoint(a, b)
   case 'binary':
   case 'uuid':
     return compareBytes(a, b)
@@ -207,6 +207,36 @@ export function compare(a, b, type) {
     if (typeName(type).startsWith('fixed[')) return compareBytes(a, b)
     return a < b ? -1 : a > b ? 1 : 0
   }
+}
+
+/**
+ * Compare two strings by Unicode code point, which is the same order as their
+ * UTF-8 byte encodings - Iceberg's order for string bounds and sort keys. JS
+ * `<` compares UTF-16 code units instead, which disagrees whenever a character
+ * in U+E000..U+FFFF meets a supplementary character (its surrogates sort below
+ * U+E000), so bounds picked or pruned with `<` can be wrong for such strings.
+ * Walking code points costs no allocation, unlike encoding both sides.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function compareStringsCodePoint(a, b) {
+  // Throw rather than coerce: pruning wraps comparisons in safeCompare, which
+  // turns a throw into "undecidable, keep the file"; a coerced comparison of a
+  // non-string literal would instead order garbage and could mis-prune.
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    throw new Error('compareStringsCodePoint expects two strings')
+  }
+  let i = 0
+  while (i < a.length && i < b.length) {
+    const ca = /** @type {number} */ (a.codePointAt(i))
+    const cb = /** @type {number} */ (b.codePointAt(i))
+    if (ca !== cb) return ca < cb ? -1 : 1
+    // Equal code points advance both strings by the same number of units.
+    i += ca > 0xffff ? 2 : 1
+  }
+  return a.length === b.length ? 0 : a.length < b.length ? -1 : 1
 }
 
 /**

--- a/test/prune.bounds.test.js
+++ b/test/prune.bounds.test.js
@@ -17,6 +17,7 @@ const schema = {
     { id: 4, name: 'price', required: false, type: 'double' },
     { id: 5, name: 'amount', required: false, type: 'decimal(10, 2)' },
     { id: 6, name: 'd', required: false, type: 'date' },
+    { id: 7, name: 'blob', required: false, type: 'binary' },
   ],
 }
 
@@ -159,14 +160,72 @@ describe('fileMightMatch — decimal', () => {
   })
 })
 
-describe('fileMightMatch — conservative cases (always keep)', () => {
-  it('string range never prunes (truncated bounds)', () => {
-    const e = entry({ 2: { min: 'aaa', max: 'mmm', type: 'string' } })
-    expect(fileMightMatch({ name: { $gt: 'zzz' } }, e, schema)).toBe(true)
-    expect(fileMightMatch({ name: { $eq: 'qqq' } }, e, schema)).toBe(true)
-    expect(fileMightMatch({ name: { $lt: 'aaa' } }, e, schema)).toBe(true)
+describe('fileMightMatch — string bounds (byte-ordered family)', () => {
+  // name (string) in ['delta', 'mango']
+  const e = entry({ 2: { min: 'delta', max: 'mango', type: 'string' } })
+
+  it('equality prunes outside the bounds and keeps inside', () => {
+    expect(fileMightMatch({ name: { $eq: 'apple' } }, e, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $eq: 'zebra' } }, e, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $eq: 'fig' } }, e, schema)).toBe(true)
+    expect(fileMightMatch({ name: { $eq: 'delta' } }, e, schema)).toBe(true)
+    expect(fileMightMatch({ name: { $eq: 'mango' } }, e, schema)).toBe(true)
   })
 
+  it('range predicates skip vs keep at boundaries', () => {
+    expect(fileMightMatch({ name: { $gt: 'mango' } }, e, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $gte: 'mango' } }, e, schema)).toBe(true)
+    expect(fileMightMatch({ name: { $lt: 'delta' } }, e, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $lte: 'delta' } }, e, schema)).toBe(true)
+  })
+
+  it('$in prunes only when every value is out of range', () => {
+    expect(fileMightMatch({ name: { $in: ['apple', 'zebra'] } }, e, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $in: ['apple', 'fig'] } }, e, schema)).toBe(true)
+  })
+
+  it('$ne keeps even on single-valued bounds: undecidable under truncation', () => {
+    const single = entry({ 2: { min: 'fig', max: 'fig', type: 'string' } })
+    expect(fileMightMatch({ name: { $ne: 'fig' } }, single, schema)).toBe(true)
+  })
+
+  it('truncated bounds act as outer bounds', () => {
+    // Writer truncation widens, never narrows: the stored lower is a prefix of
+    // the true minimum ('aaaa' bounds a min of 'aaaaq...'), the stored upper
+    // has its last unit incremented ('ab' bounds a max of 'aazz...'). Values
+    // outside the widened range prune; values in the slack the widening opened
+    // keep.
+    const t = entry({ 2: { min: 'aaaa', max: 'ab', type: 'string' } })
+    expect(fileMightMatch({ name: { $eq: 'a' } }, t, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $eq: 'ac' } }, t, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $eq: 'aaz' } }, t, schema)).toBe(true)
+    expect(fileMightMatch({ name: { $eq: 'aaaa' } }, t, schema)).toBe(true)
+  })
+
+  it('orders by code point (UTF-8 byte order), not UTF-16 code units', () => {
+    // U+E000 sorts below U+10000 in code point/UTF-8 order but above its
+    // surrogate pair in UTF-16 unit order. A file bounded at ['a', U+E000]
+    // cannot contain U+10000; UTF-16 ordering would wrongly keep it.
+    const u = entry({ 2: { min: 'a', max: '\uE000', type: 'string' } })
+    expect(fileMightMatch({ name: { $eq: '\u{10000}' } }, u, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $gt: '\uE000' } }, u, schema)).toBe(false)
+    expect(fileMightMatch({ name: { $eq: '\uE000' } }, u, schema)).toBe(true)
+  })
+
+  it('a mismatched literal type keeps the file', () => {
+    expect(fileMightMatch({ name: { $eq: 42 } }, e, schema)).toBe(true)
+    expect(fileMightMatch({ name: { $gt: 42 } }, e, schema)).toBe(true)
+  })
+
+  it('binary bounds prune bytewise', () => {
+    const b = entry({ 7: { min: new Uint8Array([2, 0]), max: new Uint8Array([5]), type: 'binary' } })
+    expect(fileMightMatch({ blob: { $eq: new Uint8Array([1]) } }, b, schema)).toBe(false)
+    expect(fileMightMatch({ blob: { $eq: new Uint8Array([9]) } }, b, schema)).toBe(false)
+    expect(fileMightMatch({ blob: { $eq: new Uint8Array([3]) } }, b, schema)).toBe(true)
+  })
+})
+
+describe('fileMightMatch — conservative cases (always keep)', () => {
   it('missing bounds for the predicated column keeps the file', () => {
     const e = entry({ 1: { min: 1n, max: 5n, type: 'long' } })
     // predicate on price, which has no bounds in this entry

--- a/test/prune.test.js
+++ b/test/prune.test.js
@@ -62,12 +62,16 @@ describe('partitionMightMatch — identity', () => {
     expect(partitionMightMatch({ id: { $nin: [1n] } }, entry({ id: 5 }), schema, m)).toBe(true)
   })
 
-  it('prunes string identity on equality only', () => {
+  it('prunes string identity on equality and ranges (code-point order)', () => {
     const sm = meta([{ 'source-id': 2, 'field-id': 1000, name: 'name', transform: 'identity' }])
     expect(partitionMightMatch({ name: { $eq: 'a' } }, entry({ name: 'a' }), schema, sm)).toBe(true)
     expect(partitionMightMatch({ name: { $eq: 'a' } }, entry({ name: 'b' }), schema, sm)).toBe(false)
-    // String ordering is left to the engine, so range predicates never prune.
-    expect(partitionMightMatch({ name: { $gt: 'a' } }, entry({ name: 'a' }), schema, sm)).toBe(true)
+    // Strings order by code point (UTF-8 byte order), so ranges prune too.
+    // Identity is exact: every row equals the partition value, so $gt 'a'
+    // on a file whose value IS 'a' proves no row can match.
+    expect(partitionMightMatch({ name: { $gt: 'a' } }, entry({ name: 'a' }), schema, sm)).toBe(false)
+    expect(partitionMightMatch({ name: { $gt: 'a' } }, entry({ name: 'b' }), schema, sm)).toBe(true)
+    expect(partitionMightMatch({ name: { $lt: 'a' } }, entry({ name: 'b' }), schema, sm)).toBe(false)
   })
 
   it('prunes a null partition value only on equality with a concrete literal', () => {


### PR DESCRIPTION
Fixes #34.

## What

1. **`isOrderableForBounds` admits the byte-ordered family** (`string`, `binary`, `uuid`, `fixed[...]`), so `boundsMightMatch` can prune files on their manifest bounds. The truncation argument: Iceberg's `truncate(16)` metrics keep bounds valid as OUTER bounds (a truncated lower bound is a prefix of the minimum, byte-order `<= min`; a truncated upper bound has its last unit incremented, `>= max`, or is omitted when incrementing overflows, which already reads as open-above). Every skip in `boundsOpMightMatch` requires the predicate to be provably outside `[lo, hi]`, which outer bounds only ever widen, so the existing operator logic is truncation-safe as written. `$ne`/`$nin`, the only operators that would need exact single-value bounds, already keep.
2. **Strings compare by code point** (`compareStringsCodePoint` in serde.js), which equals UTF-8 byte order - Iceberg's canonical string order for bounds and sort keys. JS `<` compares UTF-16 code units, which disagree whenever a character in U+E000..U+FFFF meets a supplementary character. Because `compare` is shared, this also fixes two latent writer-side bugs for such strings: `computeColumnStats` could select the wrong min/max (producing bounds that do not bound), and write-path sorting ordered them off-spec. The comparator walks code points with no allocation (the writer compares full column values per row, which can be megabytes) and throws on non-string input so `safeCompare` degrades a mismatched literal to keep-the-file instead of ordering garbage.
3. **Identity string partitions gain range pruning** through the same comparator (`compareOrder` now orders strings), with identity's exact semantics: `$gt 'a'` on a file whose partition value is `'a'` proves no row can match.

## Why

Measured production impact in hyparam/hypaware-server#317: a multi-GB table whose day idiom is a string `date` column read its ENTIRE archive on every query because string bounds never pruned - ~8s and 2,587 MB per query against 0.74s and 12 MB for an equivalent int predicate through the same path. The manifests already carried exact bounds (`lower = upper = "2026-07-09"`).

## Tests

- `prune.bounds.test.js`: new string-bounds suite - eq/range/in skip-vs-keep at boundaries, `$ne` keeps on single-valued bounds, truncated bounds acting as outer bounds (prefix lower, incremented upper), the UTF-16 vs UTF-8 divergence case (`U+10000` vs a `U+E000` bound), mismatched literal type keeps, binary bytewise pruning. The old "string range never prunes" conservative case is superseded by this suite.
- `prune.test.js`: identity string partition now asserts range pruning with exact identity semantics.
- Full suite: 639 passed. Lint and `build:types` clean.

## Caveat noted for review

Bounds decode via `TextDecoder` before comparison. A writer that truncated mid-character (spec forbids this; bounds must remain valid UTF-8) would decode partial bytes to U+FFFD and could compare differently from the raw bytes. Spec-compliant writers, including this repo's `truncateLower`/`truncateUpper`, are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
