### PR TITLE
Pushed-down WHERE agrees with the engine on null cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "hyparquet": "1.28.1",
+    "hyparquet": "1.28.2",
     "hyparquet-compressors": "1.1.1",
     "hyparquet-writer": "0.16.6",
     "squirreling": "0.15.0"

--- a/src/sql/whereFilter.js
+++ b/src/sql/whereFilter.js
@@ -93,17 +93,16 @@ function convertBinary({ op, left, right }, negate) {
  *
  * squirreling's `applyBinaryOp` returns false for any comparison with a null
  * operand, so a null cell never satisfies a bare comparison, and always
- * satisfies a negated one. hyparquet's `matchFilter` instead evaluates
- * $lt/$lte/$gt/$gte with raw JavaScript operators, where a null cell coerces
- * to 0 and can satisfy the bound (`null <= new Date()` is true), and it
- * evaluates $ne as `!equals(null, target)`, which is true. Since a converted
- * filter replaces engine-side WHERE rather than pre-filtering for it, those
- * rows would be returned by a query that excludes them.
+ * satisfies a negated one. hyparquet (>= 1.28.2) agrees on bare comparisons:
+ * $eq is false on a null cell and $lt/$lte/$gt/$gte never match one. The two
+ * disagreements left are MongoDB semantics, not bugs:
  *
- * The two operators that already agree are left alone, so the common
- * `col = value` predicate keeps its bare shape: $eq is false on a null cell,
- * which is what a bare comparison needs, and $ne is true on one, which is what
- * a negated comparison needs.
+ * - $ne is true on a null cell, so a bare `col != value` would return null
+ *   rows the engine excludes. Guard with `col $ne null`.
+ * - A negated comparison flips the operator (`NOT (n < 7)` becomes $gte),
+ *   which is false on a null cell, but the engine's NOT over a false
+ *   comparison keeps null rows. Guard with `col $eq null` in an $or. $ne is
+ *   the exception: it is true on a null cell, which is what negation needs.
  *
  * @param {ParquetQueryFilter} predicate
  * @param {string} column
@@ -116,8 +115,8 @@ function guardNull(predicate, column, mongoOp, negate) {
     if (mongoOp === '$ne') return predicate
     return { $or: [{ [column]: { $eq: null } }, predicate] }
   }
-  if (mongoOp === '$eq') return predicate
-  return { $and: [{ [column]: { $ne: null } }, predicate] }
+  if (mongoOp === '$ne') return { $and: [{ [column]: { $ne: null } }, predicate] }
+  return predicate
 }
 
 /**

--- a/src/sql/whereFilter.js
+++ b/src/sql/whereFilter.js
@@ -3,6 +3,10 @@
  * Returns undefined when any sub-expression can't be converted, so callers
  * can fall back to engine-side filtering.
  *
+ * A converted filter replaces engine-side WHERE rather than pre-filtering for
+ * it, so it must select exactly the rows the engine selects - including on
+ * null cells, where the two evaluators disagree by default (see `guardNull`).
+ *
  * Filter keys are the SQL identifier names (iceberg field names as exposed by
  * the data source). Per-file mapping to physical parquet column names happens
  * downstream in `readDataFile`.
@@ -74,10 +78,46 @@ function convertBinary({ op, left, right }, negate) {
 
   const { column, value, flipped } = extractColumnAndValue(left, right)
   if (!column || value === undefined) return undefined
+  // A comparison against a NULL literal is false for every row in the engine
+  // (`applyBinaryOp` short-circuits on a null operand), but {$eq: null} means
+  // "is null" to hyparquet. Let the engine answer it.
+  if (value === null) return undefined
 
   const mongoOp = mapOperator(op, flipped, negate)
   if (!mongoOp) return undefined
-  return { [column]: { [mongoOp]: value } }
+  return guardNull({ [column]: { [mongoOp]: value } }, column, mongoOp, negate)
+}
+
+/**
+ * Make a comparison agree with the engine on null cells.
+ *
+ * squirreling's `applyBinaryOp` returns false for any comparison with a null
+ * operand, so a null cell never satisfies a bare comparison, and always
+ * satisfies a negated one. hyparquet's `matchFilter` instead evaluates
+ * $lt/$lte/$gt/$gte with raw JavaScript operators, where a null cell coerces
+ * to 0 and can satisfy the bound (`null <= new Date()` is true), and it
+ * evaluates $ne as `!equals(null, target)`, which is true. Since a converted
+ * filter replaces engine-side WHERE rather than pre-filtering for it, those
+ * rows would be returned by a query that excludes them.
+ *
+ * The two operators that already agree are left alone, so the common
+ * `col = value` predicate keeps its bare shape: $eq is false on a null cell,
+ * which is what a bare comparison needs, and $ne is true on one, which is what
+ * a negated comparison needs.
+ *
+ * @param {ParquetQueryFilter} predicate
+ * @param {string} column
+ * @param {string} mongoOp
+ * @param {boolean} negate
+ * @returns {ParquetQueryFilter}
+ */
+function guardNull(predicate, column, mongoOp, negate) {
+  if (negate) {
+    if (mongoOp === '$ne') return predicate
+    return { $or: [{ [column]: { $eq: null } }, predicate] }
+  }
+  if (mongoOp === '$eq') return predicate
+  return { $and: [{ [column]: { $ne: null } }, predicate] }
 }
 
 /**
@@ -131,6 +171,10 @@ function staticLiteral(node) {
 function foldCast(toType, val) {
   if (val === null || val === undefined) return undefined
   if (toType === 'TEXT' || toType === 'STRING' || toType === 'VARCHAR') {
+    // The engine JSON-stringifies objects here rather than using String(), so
+    // CAST(TIMESTAMP '...' AS TEXT) would fold to a different string. Its
+    // stringify helper is not exported, so fall back rather than copy it.
+    if (typeof val === 'object') return undefined
     return { value: String(val) }
   }
   if (toType === 'INTEGER' || toType === 'INT') {

--- a/test/sql/whereFilter.equivalence.test.js
+++ b/test/sql/whereFilter.equivalence.test.js
@@ -1,0 +1,97 @@
+import { collect, executeSql } from 'squirreling'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { fileCatalogCommit } from '../../src/write/commit.js'
+import { icebergCreate } from '../../src/create.js'
+import { icebergQuery } from '../../src/sql/icebergQuery.js'
+import { icebergStageAppend } from '../../src/write/stage.js'
+import { memResolver } from '../helpers.js'
+
+/**
+ * @import {Resolver, Schema} from '../../src/types.js'
+ */
+
+/**
+ * A pushed-down filter replaces engine-side WHERE rather than pre-filtering
+ * for it, so it must select exactly the rows the engine selects. These tests
+ * run each predicate both ways over the same rows: through icebergQuery (which
+ * pushes the filter into the parquet reader) and through squirreling alone
+ * (the engine's own answer), then compare the row sets.
+ */
+describe('pushed-down WHERE matches the engine on nullable columns', () => {
+  /** @type {Schema} */
+  const schema = {
+    type: 'struct',
+    'schema-id': 0,
+    fields: [
+      { id: 1, name: 'id', required: true, type: 'long' },
+      { id: 2, name: 'n', required: false, type: 'int' },
+      { id: 3, name: 'ts', required: false, type: 'timestamptz' },
+      { id: 4, name: 's', required: false, type: 'string' },
+    ],
+  }
+
+  const records = [
+    { id: 1n, n: 5, ts: new Date('2026-08-11T00:00:00Z'), s: 'a' },
+    { id: 2n, n: null, ts: null, s: null },
+    { id: 3n, n: 9, ts: new Date('2026-08-13T00:00:00Z'), s: 'b' },
+  ]
+
+  const tableUrl = 'mem://where-null-equivalence'
+  /** @type {Resolver} */
+  let resolver
+
+  beforeAll(async () => {
+    const { resolver: memR } = memResolver()
+    const metadata = await icebergCreate({ tableUrl, resolver: memR, schema })
+    const staged = await icebergStageAppend({ tableUrl, metadata, records, resolver: memR })
+    await fileCatalogCommit({ tableUrl, metadata, staged, resolver: memR })
+    resolver = memR
+  })
+
+  /**
+   * @param {string} predicate
+   * @returns {Promise<{pushed: number[], engine: number[]}>}
+   */
+  async function bothWays(predicate) {
+    const query = `SELECT id FROM t WHERE ${predicate}`
+    const results = await icebergQuery({ query, tables: { t: tableUrl }, resolver })
+    const pushed = (await collect(results)).map(row => Number(row.id))
+    const engine = (await collect(await executeSql({ query, tables: { t: records } })))
+      .map(row => Number(row.id))
+    return { pushed, engine }
+  }
+
+  const predicates = [
+    // relational operators: a null cell coerces to 0 under hyparquet's raw
+    // JS comparison and can satisfy the bound
+    'n < 7', 'n <= 5', 'n > 3', 'n >= 9', 'n > -1', 'n < -3',
+    'ts <= TIMESTAMP \'2026-08-12T00:00:00Z\'',
+    'ts >= TIMESTAMP \'2026-08-11T00:00:00Z\'',
+    'ts > TIMESTAMP \'2026-08-12T00:00:00Z\'',
+    // equality and inequality
+    'n = 5', 'n != 5', 'n <> 5',
+    // negation: the engine's NOT over a false comparison keeps null rows
+    'NOT (n = 5)', 'NOT (n != 5)', 'NOT (n < 7)', 'NOT (n >= 7)', 'NOT (n > 3)',
+    // literal on the left
+    '5 > n', '5 = n', 'NOT (5 < n)',
+    // NULL literal operands
+    'n = NULL', 'n != NULL', 'n < NULL', 'NOT (n = NULL)',
+    // explicit null tests, which the engine and hyparquet already agree on
+    'n IS NULL', 'n IS NOT NULL', 'NOT (n IS NULL)',
+    // IN lists
+    'n IN (5, 9)', 'n NOT IN (5, 9)', 'n IN (5, NULL)', 'n NOT IN (5, NULL)',
+    'NOT (n IN (5, 9))',
+    // compound
+    'n = 5 AND ts IS NOT NULL', 'n < 7 OR n > 8', 'NOT (n < 7 AND ts IS NOT NULL)',
+    // TEXT cast of a non-primitive literal
+    's = CAST(TIMESTAMP \'2026-08-11T00:00:00Z\' AS TEXT)',
+    's = CAST(5 AS TEXT)',
+  ]
+
+  for (const predicate of predicates) {
+    it(`agrees for ${predicate}`, async () => {
+      const { pushed, engine } = await bothWays(predicate)
+      expect(pushed).toEqual(engine)
+    })
+  }
+})

--- a/test/sql/whereFilter.test.js
+++ b/test/sql/whereFilter.test.js
@@ -70,33 +70,70 @@ describe.concurrent('whereToParquetFilter', () => {
 
   it('flips literal = identifier into a column-first predicate', () => {
     const where = bin('<', lit(5), id('rank'))
-    expect(whereToParquetFilter(where)).toEqual({ rank: { $gt: 5 } })
+    expect(whereToParquetFilter(where)).toEqual({
+      $and: [{ rank: { $ne: null } }, { rank: { $gt: 5 } }],
+    })
   })
 
   it('maps all comparison operators', () => {
     /** @type {Array<[string, string]>} */
     const cases = [
-      ['=', '$eq'], ['==', '$eq'],
       ['!=', '$ne'], ['<>', '$ne'],
       ['<', '$lt'], ['<=', '$lte'],
       ['>', '$gt'], ['>=', '$gte'],
     ]
     for (const [op, mongo] of cases) {
       const where = bin(op, id('x'), lit(3))
-      expect(whereToParquetFilter(where)).toEqual({ x: { [mongo]: 3 } })
+      expect(whereToParquetFilter(where)).toEqual({
+        $and: [{ x: { $ne: null } }, { x: { [mongo]: 3 } }],
+      })
     }
+    // $eq is already false on a null cell, so it needs no guard
+    expect(whereToParquetFilter(bin('=', id('x'), lit(3)))).toEqual({ x: { $eq: 3 } })
+    expect(whereToParquetFilter(bin('==', id('x'), lit(3)))).toEqual({ x: { $eq: 3 } })
   })
 
   it('combines AND/OR', () => {
     const where = bin('AND', bin('=', id('a'), lit(1)), bin('>', id('b'), lit(2)))
     expect(whereToParquetFilter(where)).toEqual({
-      $and: [{ a: { $eq: 1 } }, { b: { $gt: 2 } }],
+      $and: [
+        { a: { $eq: 1 } },
+        { $and: [{ b: { $ne: null } }, { b: { $gt: 2 } }] },
+      ],
     })
   })
 
   it('negates by inverting operator under NOT', () => {
     const where = un('NOT', bin('<', id('a'), lit(5)))
-    expect(whereToParquetFilter(where)).toEqual({ a: { $gte: 5 } })
+    expect(whereToParquetFilter(where)).toEqual({
+      $or: [{ a: { $eq: null } }, { a: { $gte: 5 } }],
+    })
+  })
+
+  it('guards comparisons so null cells match the engine', () => {
+    // The engine's applyBinaryOp returns false for any comparison with a null
+    // operand, so a null cell never satisfies a bare comparison and always
+    // satisfies a negated one. hyparquet's raw JS comparisons disagree.
+    expect(whereToParquetFilter(bin('<=', id('a'), lit(5)))).toEqual({
+      $and: [{ a: { $ne: null } }, { a: { $lte: 5 } }],
+    })
+    expect(whereToParquetFilter(bin('!=', id('a'), lit(5)))).toEqual({
+      $and: [{ a: { $ne: null } }, { a: { $ne: 5 } }],
+    })
+    expect(whereToParquetFilter(un('NOT', bin('!=', id('a'), lit(5))))).toEqual({
+      $or: [{ a: { $eq: null } }, { a: { $eq: 5 } }],
+    })
+    // $ne under NOT is already true on a null cell, so it needs no guard
+    expect(whereToParquetFilter(un('NOT', bin('=', id('a'), lit(5))))).toEqual({ a: { $ne: 5 } })
+  })
+
+  it('falls back for a comparison against a NULL literal', () => {
+    // The engine answers `a = NULL` false for every row; {$eq: null} would
+    // instead return exactly the null rows.
+    expect(whereToParquetFilter(bin('=', id('a'), lit(null)))).toBeUndefined()
+    expect(whereToParquetFilter(bin('!=', id('a'), lit(null)))).toBeUndefined()
+    expect(whereToParquetFilter(bin('<', id('a'), lit(null)))).toBeUndefined()
+    expect(whereToParquetFilter(un('NOT', bin('=', id('a'), lit(null))))).toBeUndefined()
   })
 
   it('converts IS NULL and IS NOT NULL, including negation', () => {
@@ -163,18 +200,25 @@ describe.concurrent('whereToParquetFilter', () => {
   it('converts a TIMESTAMP typed literal into a Date predicate', () => {
     const where = bin('>=', id('message_created_at'), cast('TIMESTAMP', lit('2026-08-06T00:00:00Z')))
     expect(whereToParquetFilter(where)).toEqual({
-      message_created_at: { $gte: new Date('2026-08-06T00:00:00Z') },
+      $and: [
+        { message_created_at: { $ne: null } },
+        { message_created_at: { $gte: new Date('2026-08-06T00:00:00Z') } },
+      ],
     })
   })
 
   it('flips a TIMESTAMP literal on the left of the comparison', () => {
     const where = bin('>', cast('TIMESTAMP', lit('2026-08-06T00:00:00Z')), id('ts'))
-    expect(whereToParquetFilter(where)).toEqual({ ts: { $lt: new Date('2026-08-06T00:00:00Z') } })
+    expect(whereToParquetFilter(where)).toEqual({
+      $and: [{ ts: { $ne: null } }, { ts: { $lt: new Date('2026-08-06T00:00:00Z') } }],
+    })
   })
 
   it('negates a TIMESTAMP comparison under NOT', () => {
     const where = un('NOT', bin('<', id('ts'), cast('TIMESTAMP', lit('2026-08-06T00:00:00Z'))))
-    expect(whereToParquetFilter(where)).toEqual({ ts: { $gte: new Date('2026-08-06T00:00:00Z') } })
+    expect(whereToParquetFilter(where)).toEqual({
+      $or: [{ ts: { $eq: null } }, { ts: { $gte: new Date('2026-08-06T00:00:00Z') } }],
+    })
   })
 
   it('casts numeric epoch literals to TIMESTAMP', () => {
@@ -189,6 +233,13 @@ describe.concurrent('whereToParquetFilter', () => {
     expect(whereToParquetFilter(bin('=', id('a'), cast('DOUBLE', lit('2.5'))))).toEqual({ a: { $eq: 2.5 } })
     expect(whereToParquetFilter(bin('=', id('a'), cast('BOOL', lit(1))))).toEqual({ a: { $eq: true } })
     expect(whereToParquetFilter(bin('=', id('a'), cast('TEXT', lit(5))))).toEqual({ a: { $eq: '5' } })
+  })
+
+  it('falls back for a TEXT cast of a non-primitive literal', () => {
+    // The engine JSON-stringifies objects for a TEXT cast, so a Date folds to
+    // '"2026-08-06T00:00:00.000Z"', not its String() form.
+    const where = bin('=', id('s'), cast('TEXT', cast('TIMESTAMP', lit('2026-08-06T00:00:00Z'))))
+    expect(whereToParquetFilter(where)).toBeUndefined()
   })
 
   it('folds nested casts', () => {

--- a/test/sql/whereFilter.test.js
+++ b/test/sql/whereFilter.test.js
@@ -70,36 +70,33 @@ describe.concurrent('whereToParquetFilter', () => {
 
   it('flips literal = identifier into a column-first predicate', () => {
     const where = bin('<', lit(5), id('rank'))
-    expect(whereToParquetFilter(where)).toEqual({
-      $and: [{ rank: { $ne: null } }, { rank: { $gt: 5 } }],
-    })
+    expect(whereToParquetFilter(where)).toEqual({ rank: { $gt: 5 } })
   })
 
   it('maps all comparison operators', () => {
     /** @type {Array<[string, string]>} */
     const cases = [
-      ['!=', '$ne'], ['<>', '$ne'],
+      ['=', '$eq'], ['==', '$eq'],
       ['<', '$lt'], ['<=', '$lte'],
       ['>', '$gt'], ['>=', '$gte'],
     ]
     for (const [op, mongo] of cases) {
       const where = bin(op, id('x'), lit(3))
-      expect(whereToParquetFilter(where)).toEqual({
-        $and: [{ x: { $ne: null } }, { x: { [mongo]: 3 } }],
-      })
+      expect(whereToParquetFilter(where)).toEqual({ x: { [mongo]: 3 } })
     }
-    // $eq is already false on a null cell, so it needs no guard
-    expect(whereToParquetFilter(bin('=', id('x'), lit(3)))).toEqual({ x: { $eq: 3 } })
-    expect(whereToParquetFilter(bin('==', id('x'), lit(3)))).toEqual({ x: { $eq: 3 } })
+    // $ne is true on a null cell (mongodb semantics), so it is guarded
+    expect(whereToParquetFilter(bin('!=', id('x'), lit(3)))).toEqual({
+      $and: [{ x: { $ne: null } }, { x: { $ne: 3 } }],
+    })
+    expect(whereToParquetFilter(bin('<>', id('x'), lit(3)))).toEqual({
+      $and: [{ x: { $ne: null } }, { x: { $ne: 3 } }],
+    })
   })
 
   it('combines AND/OR', () => {
     const where = bin('AND', bin('=', id('a'), lit(1)), bin('>', id('b'), lit(2)))
     expect(whereToParquetFilter(where)).toEqual({
-      $and: [
-        { a: { $eq: 1 } },
-        { $and: [{ b: { $ne: null } }, { b: { $gt: 2 } }] },
-      ],
+      $and: [{ a: { $eq: 1 } }, { b: { $gt: 2 } }],
     })
   })
 
@@ -113,10 +110,10 @@ describe.concurrent('whereToParquetFilter', () => {
   it('guards comparisons so null cells match the engine', () => {
     // The engine's applyBinaryOp returns false for any comparison with a null
     // operand, so a null cell never satisfies a bare comparison and always
-    // satisfies a negated one. hyparquet's raw JS comparisons disagree.
-    expect(whereToParquetFilter(bin('<=', id('a'), lit(5)))).toEqual({
-      $and: [{ a: { $ne: null } }, { a: { $lte: 5 } }],
-    })
+    // satisfies a negated one. hyparquet agrees except where mongodb
+    // semantics differ: $ne is true on a null cell, and a negated comparison
+    // flips to an operator that is false on one.
+    expect(whereToParquetFilter(bin('<=', id('a'), lit(5)))).toEqual({ a: { $lte: 5 } })
     expect(whereToParquetFilter(bin('!=', id('a'), lit(5)))).toEqual({
       $and: [{ a: { $ne: null } }, { a: { $ne: 5 } }],
     })
@@ -200,17 +197,14 @@ describe.concurrent('whereToParquetFilter', () => {
   it('converts a TIMESTAMP typed literal into a Date predicate', () => {
     const where = bin('>=', id('message_created_at'), cast('TIMESTAMP', lit('2026-08-06T00:00:00Z')))
     expect(whereToParquetFilter(where)).toEqual({
-      $and: [
-        { message_created_at: { $ne: null } },
-        { message_created_at: { $gte: new Date('2026-08-06T00:00:00Z') } },
-      ],
+      message_created_at: { $gte: new Date('2026-08-06T00:00:00Z') },
     })
   })
 
   it('flips a TIMESTAMP literal on the left of the comparison', () => {
     const where = bin('>', cast('TIMESTAMP', lit('2026-08-06T00:00:00Z')), id('ts'))
     expect(whereToParquetFilter(where)).toEqual({
-      $and: [{ ts: { $ne: null } }, { ts: { $lt: new Date('2026-08-06T00:00:00Z') } }],
+      ts: { $lt: new Date('2026-08-06T00:00:00Z') },
     })
   })
 


### PR DESCRIPTION
Fixes #36.

`whereToParquetFilter`'s output **replaces** engine-side WHERE (`icebergDataSource` sets `appliedWhere: true` whenever the conversion succeeds), so it has to select exactly the rows the engine selects. On columns containing nulls it did not, because the two evaluators disagreed:

- **squirreling** (`applyBinaryOp`) returns `false` for any comparison with a null operand, so a null cell never satisfies a bare comparison and always satisfies a negated one.
- **hyparquet** before 1.28.2 evaluated `$lt/$lte/$gt/$gte` with raw JS operators, where a null cell coerces to `0` (`null <= new Date()` is `true`); and it evaluates `$ne` as `!equals(null, target)`, which is `true` (correct MongoDB semantics, but not what SQL wants).

So `WHERE at <= TIMESTAMP '...'` on a nullable column returned the null rows too, and `WHERE NOT (n < 7)` dropped the null rows it should keep. Wrong answers, not slow ones.

## What changed

**1. Require hyparquet >= 1.28.2.** Its range operators now use MongoDB type bracketing: a null cell never satisfies `$lt/$lte/$gt/$gte`. That makes every bare comparison (`$eq` included) agree with the engine with no guard at all, so the common `col < value` predicate keeps its bare shape and prunes exactly as before.

**2. Guard the two remaining disagreements, which are MongoDB semantics rather than hyparquet bugs:**
- Bare `col != value`: `$ne` is `true` on a null cell in Mongo, but the engine excludes null rows. Converted to `{$and: [{col: {$ne: null}}, {col: {$ne: value}}]}`.
- Negated comparisons: `NOT (n < 7)` flips to `$gte`, which is `false` on a null cell, but the engine's NOT over a false comparison keeps null rows. Converted to `{$or: [{col: {$eq: null}}, <flipped>]}`. The exception is `NOT (a = b)` → `$ne`, already `true` on a null cell, which stays bare.

**3. Fall back for a comparison against a literal `NULL`.** `WHERE n = NULL` folded to `{n: {$eq: null}}`, which means "is null" to hyparquet and returned exactly the null rows; the engine answers it `false` for every row. `IS NULL` / `IS NOT NULL` are unaffected - they are a different AST node and were already correct.

**4. Fall back for a TEXT cast of a non-primitive.** `foldCast` used `String(val)`, but the engine JSON-stringifies objects, so `CAST(TIMESTAMP '2026-08-11T00:00:00Z' AS TEXT)` folded to a locale date string where the engine produces `"\"2026-08-11T00:00:00.000Z\""`. squirreling's `stringify` helper is not exported, so this falls back rather than copying it.

Everything else already agreed and is untouched: `=`, `IS NULL`, `IS NOT NULL`, `IN`, `NOT IN` (including a `NULL` inside the list), and `NOT (a = b)`.

## Not a pushdown regression

Every case that pushed down before still pushes down - `appliedWhere` stays `true`. Bare comparisons keep their original unguarded shape, so row-group and file-level pruning are unchanged for them; the `#20 file-level bounds pruning` and `#21 row-group pruning` suites pass unchanged, including their `dataFilesRead()` and byte-count assertions.

The `$or` shape used for negated comparisons does give up pruning on row groups that contain nulls, since `$or` can only skip when every branch can. Negated bounds are rare, and the alternative is wrong rows.

## Tests

New `test/sql/whereFilter.equivalence.test.js` builds a real 3-row Iceberg table with nullable `int`, `timestamptz` and `string` columns and runs 37 predicates **both ways** - through `icebergQuery` (pushdown) and through `executeSql` over the same records (engine truth) - asserting the row sets match. This is the invariant the converter has to hold, tested end to end through the actual parquet reader rather than at the filter-shape level. 13 of the 37 fail on `master` with hyparquet 1.28.1.

`test/sql/whereFilter.test.js` gains unit coverage for the guard shapes, the NULL-literal fallback, and the TEXT-cast fallback.

Full suite: 682 pass, lint and typecheck clean.

## Downstream

hyparam/hypaware#721 is blocked on this - it adopts this converter in place of its own, and eleven of its shipped column specs are nullable TIMESTAMP (`logs.timestamp`, `logs.observedTimestamp`, `traces.startTimestamp`, `traces.endTimestamp` among them). It needs a release to bump to.
