### PR TITLE
Fix: deletion vector delete crashes carrying over a delete entry with stats

### DIFF
--- a/src/write/manifest.js
+++ b/src/write/manifest.js
@@ -124,14 +124,18 @@ function icebergSchemaJson(schema) {
 
 /**
  * Encode an Iceberg stat map as an Avro array of {key, value} records,
- * or null if the input has no entries.
+ * or null if the input has no entries. Entries decoded by the reader already
+ * carry that array form (see `boundForField` in prune.js), so the carry-over
+ * writers pass one straight back through; hand-built entries use a plain
+ * `Record<fieldId, value>`.
  *
  * @template V
- * @param {Record<number, V>|undefined} m
+ * @param {Record<number, V>|{key: number, value: V}[]|undefined} m
  * @returns {{key: number, value: V}[]|null}
  */
 function encodeMap(m) {
   if (!m) return null
+  if (Array.isArray(m)) return m.length ? m : null
   const entries = Object.entries(m)
   if (!entries.length) return null
   return entries.map(([k, value]) => ({ key: Number(k), value }))

--- a/test/write/stage.deletion-vector.test.js
+++ b/test/write/stage.deletion-vector.test.js
@@ -478,6 +478,90 @@ describe('icebergStageDeletionVector', () => {
     expect(ids).toEqual([2n, 3n])
   })
 
+  it('carries over a position delete entry decoded by the reader', async () => {
+    // A v2 table can accumulate position delete files across two partitions,
+    // putting two entries in one delete manifest, each carrying the stat maps
+    // stage-position-delete writes. Upgrading the table to v3 leaves those
+    // files in place, so the next deletion vector delete obsoletes one entry
+    // and has to carry the other over as EXISTING. The reader decodes Iceberg
+    // stat maps as {key, value} record arrays rather than plain objects, so
+    // that write has to accept the shape the reader produced.
+    const tableUrl = 'http://test/dv-carry-over-decoded'
+    const { resolver } = memResolver()
+
+    /** @type {Schema} */
+    const partitioned = {
+      type: 'struct',
+      'schema-id': 0,
+      fields: [
+        { id: 1, name: 'id', required: true, type: 'long' },
+        { id: 2, name: 'part', required: true, type: 'string' },
+      ],
+    }
+    const partitionSpec = {
+      'spec-id': 0,
+      fields: [{ 'source-id': 2, 'field-id': 1000, name: 'part', transform: 'identity' }],
+    }
+    const created = await icebergCreate({ tableUrl, resolver, schema: partitioned, partitionSpec })
+
+    // One append per partition, so each partition's data file is named by its
+    // own staging result rather than looked up by partition value.
+    const appendX = await icebergStageAppend({
+      tableUrl, metadata: created, resolver,
+      records: [{ id: 1n, part: 'x' }, { id: 2n, part: 'x' }],
+    })
+    const afterX = await fileCatalogCommit({ tableUrl, metadata: created, staged: appendX, resolver })
+    const appendY = await icebergStageAppend({
+      tableUrl, metadata: afterX, resolver,
+      records: [{ id: 3n, part: 'y' }, { id: 4n, part: 'y' }],
+    })
+    const afterAppend = await fileCatalogCommit({ tableUrl, metadata: afterX, staged: appendY, resolver })
+    const fileX = appendX.writtenFiles[0]
+    const fileY = appendY.writtenFiles[0]
+
+    // One position-delete op touching both partitions: two delete files, one
+    // manifest. A single-partition delete would leave nothing to carry over.
+    const deletes = await icebergStagePositionDelete({
+      tableUrl,
+      metadata: afterAppend,
+      deletes: [{ file_path: fileX, pos: 0n }, { file_path: fileY, pos: 0n }],
+      resolver,
+    })
+    const afterDeletes = await fileCatalogCommit({ tableUrl, metadata: afterAppend, staged: deletes, resolver })
+    const deleteManifest = deletes.writtenFiles.find(f => f.endsWith('.avro') && !f.includes('snap-'))
+    if (!deleteManifest) throw new Error('expected a delete manifest')
+    expect(await fetchAvroRecords(deleteManifest, resolver)).toHaveLength(2)
+
+    const upgraded = { ...afterDeletes, 'format-version': /** @type {3} */ (3), 'next-row-id': 0 }
+
+    // Targets partition x only, so its position delete entry goes obsolete
+    // and partition y's entry is carried over.
+    const staged = await icebergStageDeletionVector({
+      tableUrl,
+      metadata: upgraded,
+      deletes: [{ file_path: fileX, pos: 1n }],
+      resolver,
+    })
+
+    const afterDv = await fileCatalogCommit({ tableUrl, metadata: upgraded, staged, resolver })
+    const carried = (await currentManifestEntries(afterDv, resolver))
+      .filter(e => e.data_file.content === 1 && e.status === 0)
+    expect(carried).toHaveLength(1)
+    // The stats came through the carry-over intact rather than being dropped
+    // or re-encoded. The retained delete file covers position 0 of partition
+    // y's data file, so both `pos` bounds (reserved field id 2147483545) are
+    // the 8-byte little-endian encoding of 0.
+    expect(carried[0].data_file.lower_bounds).toContainEqual({
+      key: 2147483545, value: new Uint8Array(8),
+    })
+    expect(carried[0].data_file.upper_bounds).toContainEqual({
+      key: 2147483545, value: new Uint8Array(8),
+    })
+
+    const read = await icebergRead({ tableUrl, metadata: afterDv, resolver })
+    expect(read.map(r => r.id).sort((a, b) => Number(a - b))).toEqual([4n])
+  })
+
   it('preserves v3 next-row-id and emits added-rows=0', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(1700000000000)
     const tableUrl = 'http://test/dv-nextrow'


### PR DESCRIPTION
`icebergStageDeletionVector` throws out of `avroWrite` whenever it carries an
existing delete entry over into a rewritten manifest and that entry has stats
on it — `expected bigint value` or `expected Uint8Array value` depending on
which stat map comes first.

The Avro reader decodes Iceberg stat maps as arrays of `{key, value}` records
rather than plain objects. `boundForField` in `prune.js` already handles both
shapes on the read side; `encodeMap` on the write side only handled the object
form, so `writeExistingDeleteManifest` — which by definition consumes entries
the reader produced — fell over on them.

Real delete files carry those stats: the Spark and Java position deletes under
`test/files/hyperparam-iceberg` have `lower_bounds`, and the Java equality
delete has `value_counts` too. Icebird alone never reached this, since v3 won't
write new position delete files and v2 won't write deletion vectors — the two
only coexist on an upgraded table, or one another engine wrote.

The added test builds that case: a v2 table whose position deletes span two
partitions gets two entries in one delete manifest, and after an upgrade to v3
the next deletion vector delete obsoletes one and has to carry the other over.
It fails on `main` with the same error.

Not taken from a real table: the v2→v3 upgrade is a metadata edit rather than a
Spark `ALTER TABLE`, and the two-entry manifest comes from icebird's own writer.

<details>
<summary>Standalone repro</summary>

Save as `repro.mjs` at the repo root, then `node repro.mjs`:

```js
import { icebergCreate } from './src/create.js'
import { icebergRead } from './src/read.js'
import { fileCatalogCommit } from './src/write/commit.js'
import { icebergStageDeletionVector } from './src/write/stage-deletion-vector.js'
import { icebergStagePositionDelete } from './src/write/stage-position-delete.js'
import { icebergStageAppend } from './src/write/stage.js'
import { memResolver } from './test/helpers.js'
import { fetchAvroRecords } from './src/fetch.js'

const schema = {
  type: 'struct', 'schema-id': 0,
  fields: [
    { id: 1, name: 'id', required: true, type: 'long' },
    { id: 2, name: 'part', required: true, type: 'string' },
  ],
}
const partitionSpec = {
  'spec-id': 0,
  fields: [{ 'source-id': 2, 'field-id': 1000, name: 'part', transform: 'identity' }],
}

const tableUrl = 'http://test/t'
const { resolver } = memResolver()
const created = await icebergCreate({ tableUrl, resolver, schema, partitionSpec })

const appended = await icebergStageAppend({
  tableUrl, metadata: created, resolver,
  records: [
    { id: 1n, part: 'x' }, { id: 2n, part: 'x' },
    { id: 3n, part: 'y' }, { id: 4n, part: 'y' },
  ],
})
const afterAppend = await fileCatalogCommit({ tableUrl, metadata: created, staged: appended, resolver })

const snap = afterAppend.snapshots.at(-1)
const manifests = await fetchAvroRecords(snap['manifest-list'], resolver)
const byPart = new Map()
for (const m of manifests) {
  for (const e of await fetchAvroRecords(m.manifest_path, resolver)) {
    byPart.set(e.data_file.partition.part, e.data_file.file_path)
  }
}

// v2: one position-delete op across both partitions -> one delete manifest
// with two entries, each carrying value_counts / lower_bounds / upper_bounds.
const deletes = await icebergStagePositionDelete({
  tableUrl, metadata: afterAppend, resolver,
  deletes: [{ file_path: byPart.get('x'), pos: 0n }, { file_path: byPart.get('y'), pos: 0n }],
})
const afterDeletes = await fileCatalogCommit({ tableUrl, metadata: afterAppend, staged: deletes, resolver })
const deleteManifest = deletes.writtenFiles.find(f => f.endsWith('.avro') && !f.includes('snap-'))
const entries = await fetchAvroRecords(deleteManifest, resolver)
console.log('delete manifest entries:', entries.length)
console.log('lower_bounds as decoded: ', Array.isArray(entries[0].data_file.lower_bounds) ? 'array of {key, value}' : 'plain object')
console.log('v2 rows after position delete:', (await icebergRead({ tableUrl, metadata: afterDeletes, resolver })).length)

// Upgrade to v3, as ALTER TABLE ... SET TBLPROPERTIES ('format-version'='3')
// does. The position delete files stay where they are.
const upgraded = { ...afterDeletes, 'format-version': 3, 'next-row-id': 0 }
console.log('upgraded to v3')

// A DV delete against partition x only: x's position delete entry goes
// obsolete, y's has to be carried over as EXISTING.
try {
  const staged = await icebergStageDeletionVector({
    tableUrl, metadata: upgraded, resolver,
    deletes: [{ file_path: byPart.get('x'), pos: 1n }],
  })
  const afterDv = await fileCatalogCommit({ tableUrl, metadata: upgraded, staged, resolver })
  const rows = await icebergRead({ tableUrl, metadata: afterDv, resolver })
  console.log('DV delete: OK ->', rows.map(r => r.id))
} catch (e) {
  console.log('DV delete: FAILED ->', e.message)
  console.log(e.stack.split('\n').slice(1, 4).join('\n'))
}
```

On `main`:

```
delete manifest entries: 2
lower_bounds as decoded:  array of {key, value}
v2 rows after position delete: 2
upgraded to v3
DV delete: FAILED -> expected bigint value
    at writeType (src/avro/avro.write.js:114:44)
    at writeType (src/avro/avro.write.js:134:7)
    at writeType (src/avro/avro.write.js:140:9)
```

With this change:

```
DV delete: OK -> [ 4n ]
```

</details>